### PR TITLE
Remove DefaultConsumer::safeOnce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ n/a
 
 ### Added
 
-n/a
+- An `AbstractConsumer` class that provides the `run` and `stop` methods for
+  consumers without tying them to a specific implementation of `once`.
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   exceptions unless it's a must stop or an exception thrown from a driver. All
   other exceptions are logged, but not fatal. The idea here is to make consumers
   safe to decorate without having to duplicate the error handling logic.
+- `Consumer` has docblocks that reflect its actual return values now.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- PHP version requirement was bumped to 5.6 (BC BREAK)
+- [BC BREAK] PHP version requirement was bumped to 5.6
+- [BC BREAK] `DefaultConsumer::once` (and the `Consumer` interface) have been
+  changed to make `once` safe to run in a loop. In other words, it never throws
+  exceptions unless it's a must stop or an exception thrown from a driver. All
+  other exceptions are logged, but not fatal. The idea here is to make consumers
+  safe to decorate without having to duplicate the error handling logic.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## 3.0.0 (Unreleased)
+
+### Changed
+
+- PHP version requirement was bumped to 5.6 (BC BREAK)
+
+### Fixed
+
+n/a
+
+### Added
+
+n/a
+
 ## 2.0.2
 
 Simple license update.

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         { "name": "Christopher Davis", "email": "chris@pmg.com" }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": "~5.6|~7.0",
         "psr/log": "~1.0"
     },
     "require-dev": {

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -42,7 +42,7 @@ abstract class AbstractConsumer implements Consumer
 
     public function __construct(LoggerInterface $logger=null)
     {
-        $this->logger = $logger ?: new NullLogger();
+        $this->logger = $logger;
     }
 
     /**
@@ -55,14 +55,14 @@ abstract class AbstractConsumer implements Consumer
             try {
                 $this->once($queueName);
             } catch (Exception\MustStop $e) {
-                $this->logger->warning('Caught a must stop exception, exiting: {msg}', [
+                $this->getLogger()->warning('Caught a must stop exception, exiting: {msg}', [
                     'msg'   => $e->getMessage(),
                 ]);
                 $this->stop();
                 $this->exitCode = $e->getCode();
             } catch (\Exception $e)  {
                 // likely means means something went wrong with the driver
-                $this->logger->emergency('Caught an unexpected {cls} exception, exiting: {msg}', [
+                $this->getLogger()->emergency('Caught an unexpected {cls} exception, exiting: {msg}', [
                     'cls' => get_class($e),
                     'msg' => $e->getMessage(),
                 ]);
@@ -84,6 +84,10 @@ abstract class AbstractConsumer implements Consumer
 
     protected function getLogger()
     {
+        if (!$this->logger) {
+            $this->logger = new NullLogger();
+        }
+
         return $this->logger;
     }
 }

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * ABC for consumers, provides `run` and `stop` along with their default
+ * implementations to make it easier to decorate consumers to add extra stuff.
+ *
+ * @since 3.0
+ */
+abstract class AbstractConsumer implements Consumer
+{
+    const EXIT_ERROR = 2;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var boolean
+     */
+    private $running = false;
+
+    /**
+     * @var int
+     */
+    private $exitCode = 0;
+
+    public function __construct(LoggerInterface $logger=null)
+    {
+        $this->logger = $logger ?: new NullLogger();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function run($queueName)
+    {
+        $this->running = true;
+        while ($this->running) {
+            try {
+                $this->once($queueName);
+            } catch (Exception\MustStop $e) {
+                $this->logger->warning('Caught a must stop exception, exiting: {msg}', [
+                    'msg'   => $e->getMessage(),
+                ]);
+                $this->stop();
+                $this->exitCode = $e->getCode();
+            } catch (\Exception $e)  {
+                // likely means means something went wrong with the driver
+                $this->logger->emergency('Caught an unexpected {cls} exception, exiting: {msg}', [
+                    'cls' => get_class($e),
+                    'msg' => $e->getMessage(),
+                ]);
+                $this->stop();
+                $this->exitCode = self::EXIT_ERROR;
+            }
+        }
+
+        return $this->exitCode;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function stop()
+    {
+        $this->running = false;
+    }
+
+    protected function getLogger()
+    {
+        return $this->logger;
+    }
+}

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -24,17 +24,22 @@ interface Consumer
      * Run the consumer for a given queue. This will block.
      *
      * @param   string $queueName The queue from which the jobs will be consumed.
-     * @return  void
+     * @return  int The exit code to be used for the consumer.
      */
     public function run($queueName);
 
     /**
      * Consume a single job from the given queue. This will block until the
-     * job is competed then return.
+     * job is competed then return. Implementations of this method MUST be
+     * safe to run in a loop.
      *
      * @param   string $queueName The queue from which jobs will be consumed.
-     * @throws  Exception if anything goes wrong
-     * @return  void
+     * @throws  Exception\MustStop if the executor or handler throws a must
+     *          stop execption indicating a graceful stop is necessary
+     * @throws  Exception\DriverError|Exception if anything goes wrong with the
+     *          underlying driver itself.
+     * @return  boolean|null True if the a job was execute successfully. Null if
+     *          no job was executed. See the logs.
      */
     public function once($queueName);
 

--- a/src/DefaultConsumer.php
+++ b/src/DefaultConsumer.php
@@ -23,6 +23,8 @@ use Psr\Log\NullLogger;
  */
 final class DefaultConsumer implements Consumer
 {
+    const EXIT_ERROR = 2;
+
     /**
      * @var Driver
      */
@@ -72,7 +74,23 @@ final class DefaultConsumer implements Consumer
     {
         $this->running = true;
         while ($this->running) {
-            $this->safeOnce($queueName);
+            try {
+                $this->once($queueName);
+            } catch (Exception\MustStop $e) {
+                $this->logger->warning('Caught a must stop exception, exiting: {msg}', [
+                    'msg'   => $e->getMessage(),
+                ]);
+                $this->stop();
+                $this->exitCode = $e->getCode();
+            } catch (\Exception $e)  {
+                // likely means means something went wrong with the driver
+                $this->logger->emergency('Caught an unexpected {cls} exception, exiting: {msg}', [
+                    'cls' => get_class($e),
+                    'msg' => $e->getMessage(),
+                ]);
+                $this->stop();
+                $this->exitCode = self::EXIT_ERROR;
+            }
         }
 
         return $this->exitCode;
@@ -85,22 +103,15 @@ final class DefaultConsumer implements Consumer
     {
         $envelope = $this->driver->dequeue($queueName);
         if (!$envelope) {
-            return;
+            return null;
         }
 
+        $result = false;
         $message = $envelope->unwrap();
-        try {
-            $this->logger->debug('Executing message {msg}', ['msg' => $message->getName()]);
-            $result = $this->executor->execute($message);
-            $this->logger->debug('Executed message {msg}', ['msg' => $message->getName()]);
-        } catch (Exception\MustStop $e) {
-            // MustStop exceptions are thrown by handlers to indicate a
-            // graceful stop is required. So we don't wrapped them. Just rethrow
-            throw $e;
-        } catch (\Exception $e) {
-            $this->failed($queueName, $envelope);
-            throw new Exception\MessageFailed($e, $message);
-        }
+
+        $this->logger->debug('Executing message {msg}', ['msg' => $message->getName()]);
+        $result = $this->executeMessage($message);
+        $this->logger->debug('Executed message {msg}', ['msg' => $message->getName()]);
 
         if ($result) {
             $this->driver->ack($queueName, $envelope);
@@ -109,6 +120,8 @@ final class DefaultConsumer implements Consumer
             $this->failed($queueName, $envelope);
             $this->logger->debug('Failed message {msg}', ['msg' => $message->getName()]);
         }
+
+        return $result;
     }
 
     /**
@@ -119,37 +132,34 @@ final class DefaultConsumer implements Consumer
         $this->running = false;
     }
 
-    private function safeOnce($queueName)
-    {
-        try {
-            $this->once($queueName);
-        } catch (Exception\DriverError $e) {
-            $this->logger->critical('Caught a {cls} Driver Error, exiting: {msg}', [
-                'cls' => get_class($e),
-                'msg' => $e->getMessage(),
-            ]);
-            throw $e;
-        } catch (Exception\MustStop $e) {
-            $this->logger->warning('Caught a must stop exception, exiting: {msg}', [
-                'msg'   => $e->getMessage(),
-            ]);
-            $this->stop();
-            $this->exitCode = $e->getCode();
-        } catch (Exception\MessageFailed $e) {
-            $this->logger->critical('Unexpected {cls} exception handling {name} message: {msg}', [
-                'cls'   => get_class($e->getPrevious()),
-                'name'  => $e->getQueueMessage()->getName(),
-                'msg'   => $e->getMessage()
-            ]);
-        }
-    }
-
     private function failed($queueName, Envelope $env)
     {
         if ($this->retries->canRetry($env)) {
             $this->driver->retry($queueName, $env);
         } else {
             $this->driver->fail($queueName, $env);
+        }
+    }
+
+    private function executeMessage(Message $message)
+    {
+        try {
+            return $this->executor->execute($message);
+        } catch (Exception\MustStop $e) {
+            // MustStop exceptions are thrown by handlers to indicate a
+            // graceful stop is required. So we don't wrap them. Just rethrow
+            throw $e;
+        } catch (\Exception $e) {
+            // any other exception is simply logged. We and marked as failed
+            // below. We only log here because we can't make guarantees about
+            // the implementation of the executor and whether or not it actually
+            // throws exceptions on failure (see ForkingExecutor).
+            $this->logger->critical('Unexpected {cls} exception handling {name} message: {msg}', [
+                'cls'   => get_class($e),
+                'name'  => $message->getName(),
+                'msg'   => $e->getMessage()
+            ]);
+            return false;
         }
     }
 }

--- a/test/unit/AbstractConsumerTest.php
+++ b/test/unit/AbstractConsumerTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+use Psr\Log\LogLevel;
+
+class AbstractConsumerTest extends UnitTestCase
+{
+    const Q = 'TestQueue';
+
+    private $logger, $consumer, $message, $envelope;
+
+    /**
+     * This is a bad test: lots of stuff going on, but because we 
+     * don't want to block forever, it's the best we have.
+     */
+    public function testRunConsumesMessagesUntilConsumerIsStopped()
+    {
+        $this->consumer->expects($this->at(0))
+            ->method('once')
+            ->with(self::Q);
+        $this->consumer->expects($this->at(1))
+            ->method('once')
+            ->with(self::Q)
+            ->willThrowException(new Exception\SimpleMustStop('oops', 1));
+
+        $this->assertEquals(1, $this->consumer->run(self::Q));
+    }
+
+    public function testRunStopsWhenADriverErrorIsThrown()
+    {
+        $this->consumer->expects($this->at(0))
+            ->method('once')
+            ->with(self::Q);
+        $this->consumer->expects($this->at(1))
+            ->method('once')
+            ->with(self::Q)
+            ->willThrowException(new Exception\SerializationError('broke'));
+
+        $result = $this->consumer->run(self::Q);
+        $messages = $this->logger->getMessages(LogLevel::EMERGENCY);
+
+        $this->assertEquals(DefaultConsumer::EXIT_ERROR, $result);
+        $this->assertCount(1, $messages);
+        $this->assertContains('broke', $messages[0]);
+    }
+
+    protected function setUp()
+    {
+        $this->logger = new CollectingLogger();
+        $this->consumer = $this->getMockForAbstractClass(AbstractConsumer::class, [$this->logger]);
+        $this->message = new SimpleMessage('TestMessage');
+        $this->envelope = new DefaultEnvelope($this->message);
+    }
+}

--- a/test/unit/AbstractConsumerTest.php
+++ b/test/unit/AbstractConsumerTest.php
@@ -55,6 +55,19 @@ class AbstractConsumerTest extends UnitTestCase
         $this->assertContains('broke', $messages[0]);
     }
 
+    public function testConsumerWithoutLoggerPassedInCreatesANullLoggerOnDemand()
+    {
+        $consumer = $this->getMockForAbstractClass(AbstractConsumer::class);
+        $consumer->expects($this->once())
+            ->method('once')
+            ->with(self::Q)
+            ->willThrowException(new Exception\SerializationError('broke'));
+
+        $result = $consumer->run(self::Q);
+
+        $this->assertEquals(DefaultConsumer::EXIT_ERROR, $result);
+    }
+
     protected function setUp()
     {
         $this->logger = new CollectingLogger();

--- a/test/unit/CollectingLogger.php
+++ b/test/unit/CollectingLogger.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+final class CollectingLogger extends \Psr\Log\AbstractLogger
+{
+    private $messages = [];
+
+    public function log($level, $msg, array $context=array())
+    {
+        $this->messages[$level][] = strtr($msg, $this->makeReplacements($context));
+    }
+
+    public function getMessages($level=null)
+    {
+        if (null === $level) {
+            return array_merge(...$this->messages);
+        }
+
+        return isset($this->messages[$level]) ? $this->messages[$level] : [];
+    }
+
+
+    private function makeReplacements(array $context)
+    {
+        $rv = [];
+        foreach ($context as $name => $replace) {
+            $rv[sprintf('{%s}', $name)] = $replace;
+        }
+
+        return $rv;
+    }
+}

--- a/test/unit/DefaultConsumerTest.php
+++ b/test/unit/DefaultConsumerTest.php
@@ -97,49 +97,6 @@ class DefaultConsumerTest extends UnitTestCase
         $this->assertContains('TestMessage', $messages[0]);
     }
 
-    /**
-     * This is a bad test: lots of stuff going on, but because we 
-     * don't want to block forever, it's the best we have.
-     */
-    public function testRunConsumesMessagesUntilConsumerIsStopped()
-    {
-        $this->willRetry();
-        $this->driver->expects($this->exactly(3))
-            ->method('dequeue')
-            ->willReturn($this->envelope);
-        $this->driver->expects($this->once())
-            ->method('ack');
-        $this->executor->expects($this->at(0))
-            ->method('execute')
-            ->with($this->identicalTo($this->message))
-            ->willReturn(true);
-        $this->executor->expects($this->at(1))
-            ->method('execute')
-            ->with($this->identicalTo($this->message))
-            ->willThrowException(new \RuntimeException('oops'));
-        $this->executor->expects($this->at(2))
-            ->method('execute')
-            ->with($this->identicalTo($this->message))
-            ->willThrowException(new Exception\SimpleMustStop('oops', 1));
-
-        $this->assertEquals(1, $this->consumer->run(self::Q));
-    }
-
-    public function testRunStopsWhenADriverErrorIsThrown()
-    {
-        $this->driver->expects($this->once())
-            ->method('dequeue')
-            ->with(self::Q)
-            ->willThrowException(new Exception\SerializationError('broke'));
-
-        $result = $this->consumer->run(self::Q);
-        $messages = $this->logger->getMessages(LogLevel::EMERGENCY);
-
-        $this->assertEquals(DefaultConsumer::EXIT_ERROR, $result);
-        $this->assertCount(1, $messages);
-        $this->assertContains('broke', $messages[0]);
-    }
-
     protected function setUp()
     {
         $this->driver = $this->getMock(Driver::class);

--- a/test/unit/DefaultConsumerTest.php
+++ b/test/unit/DefaultConsumerTest.php
@@ -12,6 +12,8 @@
 
 namespace PMG\Queue;
 
+use Psr\Log\LogLevel;
+
 class DefaultConsumerTest extends UnitTestCase
 {
     const Q = 'TestQueue';
@@ -27,7 +29,7 @@ class DefaultConsumerTest extends UnitTestCase
         $this->executor->expects($this->never())
             ->method('execute');
 
-        $this->consumer->once(self::Q);
+        $this->assertNull($this->consumer->once(self::Q));
     }
 
     public function testOnceExecutesTheMessageAndAcknowledgesIt()
@@ -41,7 +43,7 @@ class DefaultConsumerTest extends UnitTestCase
             ->with($this->identicalTo($this->message))
             ->willReturn(true);
 
-        $this->consumer->once(self::Q);
+        $this->assertTrue($this->consumer->once(self::Q));
     }
 
     public function testOnceWithAFailedMessageAndValidRetryPutsTheMessageBackInTheQueue()
@@ -56,7 +58,7 @@ class DefaultConsumerTest extends UnitTestCase
             ->with($this->identicalTo($this->message))
             ->willReturn(false);
 
-        $this->consumer->once(self::Q);
+        $this->assertFalse($this->consumer->once(self::Q));
     }
 
     public function testFailedMessageThatCannotBeRetriedIsNotPutBackInTheQueue()
@@ -72,12 +74,9 @@ class DefaultConsumerTest extends UnitTestCase
             ->with($this->identicalTo($this->message))
             ->willReturn(false);
 
-        $this->consumer->once(self::Q);
+        $this->assertFalse($this->consumer->once(self::Q));
     }
 
-    /**
-     * @expectedException PMG\Queue\Exception\MessageFailed
-     */
     public function testOnceWithAExceptionThrownFromExecutorAndValidRetryRetriesJobAndThrows()
     {
         $this->withMessage();
@@ -90,7 +89,12 @@ class DefaultConsumerTest extends UnitTestCase
             ->with($this->identicalTo($this->message))
             ->willThrowException(new \Exception('oops'));
 
-        $this->consumer->once(self::Q);
+        $this->assertFalse($this->consumer->once(self::Q));
+        $messages = $this->logger->getMessages(LogLevel::CRITICAL);
+
+        $this->assertCount(1, $messages);
+        $this->assertContains('oops', $messages[0]);
+        $this->assertContains('TestMessage', $messages[0]);
     }
 
     /**
@@ -121,9 +125,6 @@ class DefaultConsumerTest extends UnitTestCase
         $this->assertEquals(1, $this->consumer->run(self::Q));
     }
 
-    /**
-     * @expectedException PMG\Queue\Exception\SerializationError
-     */
     public function testRunStopsWhenADriverErrorIsThrown()
     {
         $this->driver->expects($this->once())
@@ -131,7 +132,12 @@ class DefaultConsumerTest extends UnitTestCase
             ->with(self::Q)
             ->willThrowException(new Exception\SerializationError('broke'));
 
-        $this->consumer->run(self::Q);
+        $result = $this->consumer->run(self::Q);
+        $messages = $this->logger->getMessages(LogLevel::EMERGENCY);
+
+        $this->assertEquals(DefaultConsumer::EXIT_ERROR, $result);
+        $this->assertCount(1, $messages);
+        $this->assertContains('broke', $messages[0]);
     }
 
     protected function setUp()
@@ -139,7 +145,8 @@ class DefaultConsumerTest extends UnitTestCase
         $this->driver = $this->getMock(Driver::class);
         $this->executor = $this->getMock(MessageExecutor::class);
         $this->retries = $this->getMock(RetrySpec::class);
-        $this->consumer = new DefaultConsumer($this->driver, $this->executor, $this->retries);
+        $this->logger = new CollectingLogger();
+        $this->consumer = new DefaultConsumer($this->driver, $this->executor, $this->retries, $this->logger);
         $this->message = new SimpleMessage('TestMessage');
         $this->envelope = new DefaultEnvelope($this->message);
     }


### PR DESCRIPTION
And change the expected behavior of `Consumer::once` to be safe to run in a loop. The idea here is let the consumer implementation(s) be a bit more open to extension via decorators rather than `extend DefaultConsumer` -- I don't want to be tied to internal implementation BC commitments via `protected` methods and class extension.

`Consumer::once` only throws now if there's an error from the the driver itself.

Closes #14 