### PR TITLE
Support `allowed_classes` in `NativeSerializer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.1.0 (unreleased)
+
+BC Breaks:
+
+- None
+
+Bug Fixes:
+
+- None
+
+New Features:
+
+- Support for `allowed_classes` in PHP 7's `unserialize` function for
+  `NativeSerializer`
+
 ## 2.0.2
 
 Simple license update.

--- a/README.md
+++ b/README.md
@@ -284,6 +284,22 @@ implementations. By default, `PheanstalkDriver` will use use `PMG\Queue\Serializ
 which simply calls `serialize` and `unserialize` and runs the output `base64_encode`
 and `base64_decode` respectively.
 
+`NativeSerializer` supports allowed classes in PHP 7+, just give it an array of
+classes you want to be unserialized. Be sure to include `DefaultEnvelope` and
+whatever `Envelope` implemenation your driver uses.
+
+```php
+use PMG\Queue;
+
+$serializer = new NativeSerializer([
+  SomeMessage::class,
+
+  // include the queue envelope classes
+  Queue\DefaultEnvelope::class,
+  Queue\Driver\Pheanstalk\PheanstalkEnvelope::class,
+]);
+```
+
 You can (and **should**) consider wrapping the native serializer with
 `SignedSerializer` which will prepend an HMAC to the serialized message to help
 verify integrity when unserializing.

--- a/src/DefaultEnvelope.php
+++ b/src/DefaultEnvelope.php
@@ -54,4 +54,23 @@ class DefaultEnvelope implements Envelope
 
         return $new;
     }
+
+    /**
+     * checks to make sure the `$message` property is really a message. Serializes
+     * may (optionally) whitelist classes. If we don't get a message back the 
+     * envelope is kind of ****ed.
+     *
+     * @return void
+     */
+    public function __wakeup()
+    {
+        if (!$this->message instanceof Message) {
+            throw new Exception\SerializationError(sprintf(
+                '%s expected its message property to be unserialized with an instance of %s, got "%s"',
+                __CLASS__,
+                Message::class,
+                get_class($this->message)
+            ));
+        }
+    }
 }


### PR DESCRIPTION
Let's folks whitelist classes that are allowed to be unserialized. This
also adds a check in `DefaultEnvelope` during its wakeup to make sure it
actually has a Message object.

Closes #20