### PR TITLE
Remove the Lazy Creation of NativeSerializer in AbstractPersistanceDriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [BC BREAK] `PMG\Queue\Serializer\SigningSerializer` has been merged into
   `NativeSerializer` and removed. Pass your key as the first argument to
   `NativeSerializer`'s constructor.
+- [BC BREAK] `AbstractPersistanceDriver::getSerializer` was removed, use
+  `AbstractPersistanceDriver::assureSerializer` instead.
 - `Consumer` has docblocks that reflect its actual return values now.
 - `PheanstalkDriver` is no longer part of the core. Instead of requiring
    `pmg/queue` directly in your `composer.json`, require `pmg/queue-pheanstalk`

--- a/src/Driver/AbstractPersistanceDriver.php
+++ b/src/Driver/AbstractPersistanceDriver.php
@@ -30,7 +30,7 @@ abstract class AbstractPersistanceDriver implements \PMG\Queue\Driver
      */
     private $serializer;
 
-    public function __construct(Serializer $serializer=null)
+    public function __construct(Serializer $serializer)
     {
         $this->serializer = $serializer;
     }
@@ -59,18 +59,21 @@ abstract class AbstractPersistanceDriver implements \PMG\Queue\Driver
 
     protected function serialize(Envelope $env)
     {
-        return $this->getSerializer()->serialize($env);
+        return $this->assureSerializer()->serialize($env);
     }
 
     protected function unserialize($data)
     {
-        return $this->getSerializer()->unserialize($data);
+        return $this->assureSerializer()->unserialize($data);
     }
 
-    protected function getSerializer()
+    protected function assureSerializer()
     {
         if (!$this->serializer) {
-            $this->serializer = new NativeSerializer();
+            throw new \RuntimeException(sprintf(
+                '%s does not have a serializer set, did you forget to call parent::__construct($serializer) in its constructor?',
+                get_class($this)
+            ));
         }
 
         return $this->serializer;

--- a/test/unit/Driver/AbstractPersistanceDriverTest.php
+++ b/test/unit/Driver/AbstractPersistanceDriverTest.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Driver;
+
+use PMG\Queue\Envelope;
+use PMG\Queue\DefaultEnvelope;
+use PMG\Queue\SimpleMessage;
+use PMG\Queue\Serializer\Serializer;
+
+// mostly a dirty hack to expose the `serialize` and `unserialize` methods
+// as public. Also makes the serializer optional in the constructor so we can
+// verify that the ABC errors when `parent::__construct($someSerializer)` is
+// not called
+abstract class _DriverAbc extends AbstractPersistanceDriver
+{
+    public function __construct(Serializer $serializer=null)
+    {
+        if ($serializer) {
+            parent::__construct($serializer);
+        }
+    }
+
+    public function serialize(Envelope $env)
+    {
+        return parent::serialize($env);
+    }
+
+    public function unserialize($str)
+    {
+        return parent::unserialize($str);
+    }
+}
+
+class AbstractPersistanceDriverTest extends \PMG\Queue\UnitTestCase
+{
+    private $envelope;
+
+    public function testDriversSerializeMethodsWorksWhenGivenASerializer()
+    {
+        list($serializer, $driver) = $this->createDriver();
+        $serializer->expects($this->once())
+            ->method('serialize')
+            ->with($this->envelope)
+            ->willReturn($envstr = serialize($this->envelope));
+
+        $this->assertEquals($envstr, $driver->serialize($this->envelope));
+    }
+
+    public function testDriversUnserializeMethodsWorksWhenWhenASerializer()
+    {
+        list($serializer, $driver) = $this->createDriver();
+        $serializer->expects($this->once())
+            ->method('unserialize')
+            ->with(serialize($this->envelope))
+            ->willReturn($this->envelope);
+
+        $this->assertEquals($this->envelope, $driver->unserialize(serialize($this->envelope)));
+    }
+
+    public function testSerializeErrorsWhenNoSerializerWasGivenToTheConstructor()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('does not have a serializer set');
+        $this->createInvalidDriver()->serialize($this->envelope);
+    }
+
+    public function testUnserializeErrorsWhenNoSerializerWasGivenToTheConstructor()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('does not have a serializer set');
+        $this->createInvalidDriver()->unserialize(serialize($this->envelope));
+    }
+
+    protected function setUp()
+    {
+        $this->envelope = new DefaultEnvelope(new SimpleMessage('Test'));
+    }
+
+    private function createDriver()
+    {
+        $serializer = $this->getMock(Serializer::class);
+        $driver = $this->getMockForAbstractClass(_DriverAbc::class, [$serializer]);
+
+        return [$serializer, $driver];
+    }
+
+    private function createInvalidDriver()
+    {
+        return $this->getMockForAbstractClass(_DriverAbc::class);
+    }
+}


### PR DESCRIPTION
Instead require it in the constructor. This also adds some tests for the
driver ABC to make sure it actually works.

closes #29