### PR TITLE
Throw an Exception on Abnormal Exits in Child Processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 3.NEXT (Unreleased)
 
 ### Changed
-n/a
+
+- Child processes that exit abnormaly in `PcntlForkingHandler` now throw an
+  `AbnormalExit` exception with some info about what went wrong. Practically
+  this has no impact: the job is still failed and (possibly) retried, but the
+  thrown exception will be logged and hopefully give users a better place to
+  start debugging.
 
 ### Fixed
 n/a

--- a/src/Exception/AbnormalExit.php
+++ b/src/Exception/AbnormalExit.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Exception;
+
+use PMG\Queue\QueueException;
+
+/**
+ * Thrown by the `Pcntl` utility when a child process does not have a 
+ * normal exit. When this happens it's treated as a message handling failure,
+ * just like an unsuccessful exit would be.
+ *
+ * @since 3.2.0
+ */
+final class AbnormalExit extends \RuntimeException implements QueueException
+{
+    public static function fromWaitStatus($status)
+    {
+        if (pcntl_wifstopped($status)) {
+            return new self(sprintf(
+                'Child process was stopped with %s signal',
+                pcntl_wstopsig($status)
+            ));
+        }
+
+        if (pcntl_wifsignaled($status)) {
+            return new self(sprintf(
+                'Child process was terminated with %s signal',
+                pcntl_wtermsig($status)
+            ));
+        }
+
+        return new self(sprintf(
+            'Child process exited abnormally (wait status: %s)',
+            $status
+        ));
+    }
+}

--- a/test/unit/Handler/PcntlTest.php
+++ b/test/unit/Handler/PcntlTest.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Handler;
+
+use PMG\Queue\Exception\AbnormalExit;
+
+/**
+ * While most of pcntl "happy" path stuff is handled by `PcntlForkingHandlerTest`
+ * this one covers some of the less happy path stuff like abnormal exits, etc.
+ *
+ * @requires extension pcntl
+ * @requires extension posix
+ */
+class PcntlTest extends \PMG\Queue\UnitTestCase
+{
+    private $pcntl;
+
+    public function testStoppedProcessesThrowsAbnormalExit()
+    {
+        $this->expectException(AbnormalExit::class);
+        $this->expectExceptionMessage('was stopped with');
+
+        $pid = $this->fork();
+        if ($pid) {
+            posix_kill($pid, SIGSTOP);
+            $this->pcntl->wait($pid);
+        } else {
+            self::waitAndExit(5, 0);
+        }
+    }
+
+    public function testInterruptedProcessesThrowAbnormalExit()
+    {
+        $this->expectException(AbnormalExit::class);
+        $this->expectExceptionMessage('was terminated with');
+
+        $pid = $this->fork();
+        if ($pid) {
+            posix_kill($pid, SIGINT);
+            $this->pcntl->wait($pid);
+        } else {
+            self::waitAndExit(5, 0);
+        }
+    }
+
+    protected function setUp()
+    {
+        $this->pcntl = new Pcntl();
+    }
+
+    private function fork()
+    {
+        $pid = $this->pcntl->fork();
+        if (-1 === $pid) {
+            $this->markTestSkipped('Could not fork!');
+        }
+
+        return $pid;
+    }
+
+    private static function waitAndExit($time, $status)
+    {
+        sleep($time);
+        exit($status);
+    }
+}

--- a/test/unit/Handler/PcntlTest.php
+++ b/test/unit/Handler/PcntlTest.php
@@ -36,7 +36,11 @@ class PcntlTest extends \PMG\Queue\UnitTestCase
             try {
                 $this->pcntl->wait($pid);
             } finally {
+                // continue, then kill the stopped process.
+                posix_kill($pid, SIGCONT);
                 posix_kill($pid, SIGTERM);
+                pcntl_waitpid($pid, $status, WUNTRACED);
+                $this->assertTrue(pcntl_wifsignaled($status));
             }
         } else {
             self::waitAndExit(5, 0);

--- a/test/unit/Handler/PcntlTest.php
+++ b/test/unit/Handler/PcntlTest.php
@@ -33,7 +33,11 @@ class PcntlTest extends \PMG\Queue\UnitTestCase
         $pid = $this->fork();
         if ($pid) {
             posix_kill($pid, SIGSTOP);
-            $this->pcntl->wait($pid);
+            try {
+                $this->pcntl->wait($pid);
+            } finally {
+                posix_kill($pid, SIGTERM);
+            }
         } else {
             self::waitAndExit(5, 0);
         }


### PR DESCRIPTION
Previously we treated everything abnormal as a simple failure. Which can
hide a lot of issues -- like a bunch of segfaults that are super hard to
diagnose! Instead we now throw an exception. Effectively this has the
same result: the job is failed (and maybe retried), but we get an actual
error message about the exit/stop code or a wait status value if things
fail.

Closes #44 