### PR TITLE
Always `quit` in PcntlForkingHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   start debugging.
 
 ### Fixed
-n/a
+- PcntlForkingHandler now always exits, which prevents child processes from
+  turning into extra consumers and forking child processes themselves. See
+  https://github.com/AgencyPMG/Queue/pull/47
 
 ### Added
 n/a

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 .PHONY: test testnocov simpleexample retryexample
 
 testnocov:
-	php vendor/bin/phpunit
+	php vendor/bin/phpunit -v
 
 test:
-	php vendor/bin/phpunit --coverage-text
+	php vendor/bin/phpunit --coverage-text -v
 
 simpleexample:
 	php examples/simple.php

--- a/test/unit/Handler/PcntlForkingHandlerTest.php
+++ b/test/unit/Handler/PcntlForkingHandlerTest.php
@@ -56,6 +56,26 @@ class PcntlForkingHandlerTest extends \PMG\Queue\UnitTestCase
         $this->assertFalse($handler->handle($this->message));
     }
 
+    public function testChildProcessThatThrowsAnExceptionExitsUnsuccessfully()
+    {
+        $handler = $this->createHandler(function () {
+            throw new \Exception('oh noz');
+        });
+
+        $this->assertFalse($handler->handle($this->message));
+    }
+
+    public function testChildProcessWithErrorExitsUnsuccessfully()
+    {
+        $this->skipIfPhp5();
+
+        $handler = $this->createHandler(function () {
+            throw new \Error('oh noz');
+        });
+
+        $this->assertFalse($handler->handle($this->message));
+    }
+
     public function testChildProcessIsPassedTheOptionsFromTheHandler()
     {
         $handler = $this->createHandler(function ($msg, $options) {

--- a/test/unit/UnitTestCase.php
+++ b/test/unit/UnitTestCase.php
@@ -24,7 +24,7 @@ abstract class UnitTestCase extends \PHPUnit_Framework_TestCase
     protected function skipIfPhp5()
     {
         if (!self::isPhp7()) {
-            $this->markTestSkipped(sprintf('PHP 5.X is required, have %s', PHP_VERSION));
+            $this->markTestSkipped(sprintf('PHP 7.X is required, have %s', PHP_VERSION));
         }
     }
 


### PR DESCRIPTION
Otherwise a thrown exception gets propagated all the way back up to the consumer where it *is* caught. After that the child process would continue on its way and turn into a consumer itself.

Should (hopefully) fix #46 