### PR TITLE
Introduce Signers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,17 @@ n/a
 
 ### Changed
 - [BC Break] Dropped support for PHP 5.6
+- [BC Break] `NativeSerializer` now uses a `PMG\Queue\Signer\Signer` to sign
+  its message. Previously this was all handled by the serializer directly. See
+  `UPGRADE-4.0.md` for a migration path.
 
 ### Fixed
 n/a
 
 ### Added
-n/a
+- A new `PMG\Queue\Signer\Signer` interface was added as a way to make the
+  message signature generation and validation pluggable in `Serializer`
+  implementations.
 
 ## 3.2.0
 

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -2,5 +2,23 @@
 
 ## PHP Version Requirement Bumped to ~7.0
 
-Support for PHP 5.6+ dropped, you'll need to still with 3.X if you still
-need PHP 5 support.
+Support for PHP 5.6+ dropped. Stick with 3.X need PHP 5 support is still
+necessary.
+
+## `NativeSerializer` Now Requires a `Signer` Instance
+
+Previously one could pass a key to `NativeSerializer` directly. Now a `Signer`
+instance is required. A named constructor is provided if the 3.X behavior is
+still desired.
+
+```php
+use PMG\Queue\Signer\HmacSha256;
+use PMG\Queue\Serializer\NativeSerializer;
+
+// 3.X
+$serializer = new NativeSerializer('secretKey');
+
+// 4.X
+$serializer = NativeSerializer::fromSigningKey('secretKey');
+// $serializer = new NativeSerializer(new HmacSha256('secretKey'));
+```

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "psr/log": "~1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0"
+        "phpunit/phpunit": "~6.0",
+        "paragonie/sodium_compat": "^0.7"
     },
     "suggest": {
         "pmg/queue-pheanstalk": "Power pmg/queue with Beanstalkd"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "92cadc02db71d6313a9f3fbf20f0f0a0",
+    "content-hash": "2ad781154e7d61b7a0c3dc6704a6e4ba",
     "packages": [
         {
             "name": "psr/log",
@@ -150,6 +150,135 @@
                 "object graph"
             ],
             "time": "2017-04-12T18:52:22+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "reference": "634bae8e911eefa89c1abfbf1b66da679ac8f54d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2017-03-13T16:27:32+00:00"
+        },
+        {
+            "name": "paragonie/sodium_compat",
+            "version": "v0.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/sodium_compat.git",
+                "reference": "775f3ffdd87c321533678c69542a09634567af05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/775f3ffdd87c321533678c69542a09634567af05",
+                "reference": "775f3ffdd87c321533678c69542a09634567af05",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/random_compat": "^1|^2",
+                "php": "^5.2.4|^5.3|^5.4|^5.5|^5.6|^7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^3|^4|^5"
+            },
+            "suggest": {
+                "ext-libsodium": "Better performance, password hashing (Argon2i), secure memory management (memzero), and better security."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com"
+                },
+                {
+                    "name": "Frank Denis",
+                    "email": "jedisct1@pureftpd.org"
+                }
+            ],
+            "description": "Pure PHP implementation of libsodium; uses the PHP extension if it exists",
+            "keywords": [
+                "Authentication",
+                "BLAKE2b",
+                "ChaCha20",
+                "ChaCha20-Poly1305",
+                "Chapoly",
+                "Curve25519",
+                "Ed25519",
+                "EdDSA",
+                "Edwards-curve Digital Signature Algorithm",
+                "Elliptic Curve Diffie-Hellman",
+                "Poly1305",
+                "Pure-PHP cryptography",
+                "RFC 7748",
+                "RFC 8032",
+                "Salpoly",
+                "Salsa20",
+                "X25519",
+                "XChaCha20-Poly1305",
+                "XSalsa20-Poly1305",
+                "Xchacha20",
+                "Xsalsa20",
+                "aead",
+                "cryptography",
+                "ecdh",
+                "elliptic curve",
+                "elliptic curve cryptography",
+                "encryption",
+                "libsodium",
+                "php",
+                "public-key cryptography",
+                "secret-key cryptography",
+                "side-channel resistant"
+            ],
+            "time": "2017-04-12T20:13:51+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -714,16 +843,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.1.4",
+            "version": "6.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "42b7f394a8e009516582331b1e03a1aba40175d1"
+                "reference": "16999a1e9a8a25d68f0ab8cc8ab818b043ad5374"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/42b7f394a8e009516582331b1e03a1aba40175d1",
-                "reference": "42b7f394a8e009516582331b1e03a1aba40175d1",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/16999a1e9a8a25d68f0ab8cc8ab818b043ad5374",
+                "reference": "16999a1e9a8a25d68f0ab8cc8ab818b043ad5374",
                 "shasum": ""
             },
             "require": {
@@ -768,7 +897,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.1.x-dev"
+                    "dev-master": "6.2.x-dev"
                 }
             },
             "autoload": {
@@ -794,7 +923,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-05-22T07:45:30+00:00"
+            "time": "2017-06-02T12:24:37+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,9 @@
         <testsuite name="unit">
             <directory>./test/unit</directory>
         </testsuite>
+        <testsuite name="integration">
+            <directory>./test/integration</directory>
+        </testsuite>
     </testsuites>
 
     <filter>

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -22,5 +22,10 @@ use PMG\Queue\QueueException;
  */
 final class InvalidArgumentException extends \InvalidArgumentException implements QueueException
 {
-
+    public static function assertNotEmpty($value, string $message)
+    {
+        if (empty($value)) {
+            throw new self($message);
+        }
+    }
 }

--- a/src/Signer/HmacSha256.php
+++ b/src/Signer/HmacSha256.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Signer;
+
+use PMG\Queue\Exception\InvalidArgumentException;
+
+/**
+ * Uses hash_hmac and sha256 to sign/validate messages.
+ *
+ * @since 4.0
+ */
+final class HmacSha256 implements Signer
+{
+    const ALGO = 'sha256';
+
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * Constructor.
+     *
+     * @param $key The key with which messages will be signed.
+     */
+    public function __construct(string $key)
+    {
+        InvalidArgumentException::assertNotEmpty($key, '$key cannot be empty!');
+        $this->key = $key;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sign(string $message) : string
+    {
+        return hash_hmac(self::ALGO, $message, $this->key, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function verify(string $mac, string $message) : bool
+    {
+        return hash_equals($this->sign($message), $mac);
+    }
+}

--- a/src/Signer/Signer.php
+++ b/src/Signer/Signer.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Signer;
+
+/**
+ * Sign or verify messages. This is used in conjuction with `NativeSerializer`
+ * for the most part.
+ *
+ * @since 4.0
+ */
+interface Signer
+{
+    /**
+     * Sign a message.
+     *
+     * @param $message The message to signe
+     * @return a MAC that can be be associated with the message however the 
+     *         caller sees fit.
+     */
+    public function sign(string $message) : string;
+
+    /**
+     * Verify the message signature.
+     *
+     * @param $signed The signed message
+     * @return True if the message signature is valid.
+     */
+    public function verify(string $mac, string $message) : bool;
+}

--- a/src/Signer/SodiumCryptoAuth.php
+++ b/src/Signer/SodiumCryptoAuth.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Signer;
+
+use PMG\Queue\Exception\InvalidArgumentException;
+
+final class SodiumCryptoAuth implements Signer
+{
+    /**
+     * @var string
+     */
+    private $key;
+
+    /**
+     * Constructor. This tries to sign a dummy message immediately to validate
+     * that the key okay for libsodium.
+     *
+     * @param $key The key with which messages will be signed.
+     */
+    public function __construct(string $key)
+    {
+        // @codeCoverageIgnoreStart
+        if (!function_exists('sodium_crypto_auth')) {
+            throw new \RuntimeException(sprintf(
+                'sodium_* functions are not available, cannot use %s',
+                __CLASS__
+            ));
+        }
+        // @codeCoverageIgnoreEnd
+        InvalidArgumentException::assertNotEmpty($key, '$key cannot be empty!');
+        $this->key = $key;
+        try {
+            $this->sign('test message, please ignore');
+        } catch (\Throwable $e) {
+            throw new InvalidArgumentException($e->getMessage(), 0, $e);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function sign(string $message) : string
+    {
+        return sodium_crypto_auth($message, $this->key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function verify(string $mac, string $message) : bool
+    {
+        return sodium_crypto_auth_verify($mac, $message, $this->key);
+    }
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -12,3 +12,4 @@
 
 $loader = require __DIR__.'/../vendor/autoload.php';
 $loader->addPsr4('PMG\\Queue\\', __DIR__.'/unit');
+$loader->addPsr4('PMG\\Queue\\', __DIR__.'/integration');

--- a/test/integration/IntegrationTestCase.php
+++ b/test/integration/IntegrationTestCase.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+abstract class IntegrationTestCase extends \PHPUnit\Framework\TestCase
+{
+    // noop
+}

--- a/test/integration/Serializer/HmacSha256NativeSerializerTest.php
+++ b/test/integration/Serializer/HmacSha256NativeSerializerTest.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Serializer;
+
+use PMG\Queue\Envelope;
+use PMG\Queue\DefaultEnvelope;
+use PMG\Queue\SimpleMessage;
+use PMG\Queue\Exception\SerializationError;
+use PMG\Queue\Signer\HmacSha256;
+
+class HmacSha256NativeSerializerTest extends SerializerIntegrationTestCase
+{
+    const KEY = 'SuperSecretKey';
+
+    public static function notStrings()
+    {
+        return [
+            [['an array']],
+            [new \stdClass],
+            [1],
+            [1.0],
+            [null],
+            [false],
+        ];
+    }
+
+    /**
+     * @group regression
+     * @dataProvider notStrings
+     */
+    public function testSerializersCannotBeCreatedWithANonStringKey($key)
+    {
+        $this->expectException(\TypeError::class);
+
+        NativeSerializer::fromSigningKey($key);
+    }
+
+    public function testSerializersCannotBeCreatedWithEmptyKeys()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$key cannot be empty');
+
+        NativeSerializer::fromSigningKey('');
+    }
+
+    /**
+     * @group regresion
+     */
+    public function testMessagesSerializedInVersion2xCanStillBeUnserialized()
+    {
+        $oldMessage = 'bbb07fc3841b8114978c60bddcf61d3f0d167887250696a7974502f8ce42d136|TzoyNToiUE1HXFF1ZXVlXERlZmF1bHRFbnZlbG9wZSI6Mjp7czoxMDoiACoAbWVzc2FnZSI7TzoyMzoiUE1HXFF1ZXVlXFNpbXBsZU1lc3NhZ2UiOjI6e3M6Mjk6IgBQTUdcUXVldWVcU2ltcGxlTWVzc2FnZQBuYW1lIjtzOjE6InQiO3M6MzI6IgBQTUdcUXVldWVcU2ltcGxlTWVzc2FnZQBwYXlsb2FkIjtOO31zOjExOiIAKgBhdHRlbXB0cyI7aTowO30=';
+
+        $env = $this->serializer->unserialize($oldMessage);
+
+        $this->assertEquals($this->env, $env);
+    }
+
+    protected function createSerializer() : Serializer
+    {
+        return NativeSerializer::fromSigningKey(self::KEY);
+    }
+}

--- a/test/integration/Serializer/SerializerIntegrationTestCase.php
+++ b/test/integration/Serializer/SerializerIntegrationTestCase.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Serializer;
+
+use PMG\Queue\Envelope;
+use PMG\Queue\DefaultEnvelope;
+use PMG\Queue\SimpleMessage;
+use PMG\Queue\Exception\SerializationError;
+use PMG\Queue\Signer\HmacSha256;
+
+/**
+ * Covers the basic cases serializers. This exists so we can test they they
+ * play nice with the various signers.
+ */
+abstract class SerializerIntegrationTestCase extends \PMG\Queue\IntegrationTestCase
+{
+    protected $serializer;
+
+    public function testSerializeReturnsAStringThatCanBeUnserialized()
+    {
+        $s = $this->serializer->serialize($this->env);
+        $this->assertInternalType('string', $s);
+
+        $env = $this->serializer->unserialize($s);
+        $this->assertEquals($this->env, $env);
+    }
+
+    public function testUnserializeErrorsWhenAnUnsignedStringIsGiven()
+    {
+        $this->expectException(SerializationError::class);
+        $this->expectExceptionMessage('does not have a signature');
+
+        $this->serializer->unserialize(base64_encode(serialize($this->env)));
+    }
+
+    public function testUnserializeErrorsWhenTheMessageDataHasBeenTamperedWith()
+    {
+        $this->expectException(SerializationError::class);
+        $this->expectExceptionMessage('Invalid Message Signature');
+
+        $s = explode('|', $this->serializer->serialize($this->env), 2);
+        $s[1] = base64_encode(serialize(new \stdClass));
+        $str = implode('|', $s);
+
+        $this->serializer->unserialize($str);
+    }
+
+    protected function setUp()
+    {
+        $this->serializer = $this->createSerializer();
+        $this->env = new DefaultEnvelope(new SimpleMessage('t'));
+    }
+
+    abstract protected function createSerializer() : Serializer;
+}

--- a/test/integration/Serializer/SodiumCryptoAuthNativeSerializerTest.php
+++ b/test/integration/Serializer/SodiumCryptoAuthNativeSerializerTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Serializer;
+
+use PMG\Queue\Envelope;
+use PMG\Queue\DefaultEnvelope;
+use PMG\Queue\SimpleMessage;
+use PMG\Queue\Exception\SerializationError;
+use PMG\Queue\Signer\SodiumCryptoAuth;
+
+class SodiumCryptoAuthNativeSerializerTest extends SerializerIntegrationTestCase
+{
+    protected function createSerializer() : Serializer
+    {
+        return new NativeSerializer(new SodiumCryptoAuth(str_repeat('test', 8)));
+    }
+}

--- a/test/unit/Signer/HmacSha256Test.php
+++ b/test/unit/Signer/HmacSha256Test.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Signer;
+
+use PMG\Queue\Exception\InvalidArgumentException;
+
+class HmacSha256Test extends SignerTestCase
+{
+    public function testSignerCannotBeCreatedWithEmptyKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new HmacSha256('');
+    }
+
+    protected function createSigner()
+    {
+        return new HmacSha256('superSecretShhhh');
+    }
+}

--- a/test/unit/Signer/SignerTestCase.php
+++ b/test/unit/Signer/SignerTestCase.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Signer;
+
+use PMG\Queue\Exception\InvalidArgumentException;
+
+abstract class SignerTestCase extends \PMG\Queue\UnitTestCase
+{
+    protected $signer;
+
+    public function testSignReturnsAMacString()
+    {
+        $mac = $this->signer->sign('hello, world');
+
+        $this->assertInternalType('string', $mac);
+        $this->assertNotEmpty($mac);
+    }
+
+    public function testVerifyReturnsTrueWhenTheMessageIsTheSame()
+    {
+        $mac = $this->signer->sign('hello, world');
+
+        $result = $this->signer->verify($mac, 'hello, world');
+
+        $this->assertTrue($result);
+    }
+
+    public function testVerifyReturnsFalseWhenTheMessageIsNotTheSame()
+    {
+        $mac = $this->signer->sign('hello, world');
+
+        $result = $this->signer->verify($mac, 'goodbye, world');
+
+        $this->assertFalse($result);
+    }
+
+    protected function setUp()
+    {
+        $this->signer = $this->createSigner();
+    }
+
+    abstract protected function createSigner();
+}

--- a/test/unit/Signer/SodiumCryptoAuthTest.php
+++ b/test/unit/Signer/SodiumCryptoAuthTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Signer;
+
+use PMG\Queue\Exception\InvalidArgumentException;
+
+class SodiumCryptoAuthTest extends SignerTestCase
+{
+    public function testSignerCannotBeCreatedWithEmptyKey()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new SodiumCryptoAuth('');
+    }
+
+    public static function invalidKeys()
+    {
+        return [
+            'too short' => ['test'],
+            'too long' => [str_repeat('test', 100)],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidKeys
+     */
+    public function testSignerCannotBeCreatedWithInvalidKey(string $key)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new SodiumCryptoAuth($key);
+    }
+
+    protected function createSigner()
+    {
+        return new SodiumCryptoAuth(str_repeat('test', 8));
+    }
+}


### PR DESCRIPTION
Make the signature generation and validation pluggable in `NativeSerializer` (and presumably other serializer implementations as well).

This also includes a `SodiumCryptoAuth` signer that can use libsodium's `crypto_auth(_verify)` in PHP 7.2+ (or via `paragonie/sodium_compat`).

Closes #50 