### PR TITLE
Introduce Driver::release (and Other Driver Changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ n/a
   `UPGRADE-4.0.md` for a migration path.
 - [BC Break, Internals] `AbstractPersistanceDriver::assureSerializer` was renamed
   to `ensureSerializer`.
+- [BC Break, Internals] `Driver` now has more strict type declarations.
 
 ### Fixed
 n/a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ n/a
 - [BC Break, Internals] `AbstractPersistanceDriver::assureSerializer` was renamed
   to `ensureSerializer`.
 - [BC Break, Internals] `Driver` now has more strict type declarations.
+- [BC Break, Internals] `Driver::release` was introduced.
 
 ### Fixed
 n/a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ n/a
 - [BC Break] `NativeSerializer` now uses a `PMG\Queue\Signer\Signer` to sign
   its message. Previously this was all handled by the serializer directly. See
   `UPGRADE-4.0.md` for a migration path.
+- [BC Break, Internals] `AbstractPersistanceDriver::assureSerializer` was renamed
+  to `ensureSerializer`.
 
 ### Fixed
 n/a

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -22,3 +22,24 @@ $serializer = new NativeSerializer('secretKey');
 $serializer = NativeSerializer::fromSigningKey('secretKey');
 // $serializer = new NativeSerializer(new HmacSha256('secretKey'));
 ```
+
+## For Driver Authors
+
+### `assureSerializer` was renamed in `AbstractPersistanceDriver`
+
+```php
+class SomeDriver implements Driver
+{
+    private function whatever()
+    {
+        // 3.X
+        $this->assureSerializer()->serialize(...);
+
+        // 4.X
+        $this->ensureSerializer()->serialize(...);
+    }
+}
+```
+
+Prefer using `$this->serialize` or `$this->unserialize` instead of accessing the
+serializer directly.

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -25,6 +25,11 @@ $serializer = NativeSerializer::fromSigningKey('secretKey');
 
 ## For Driver Authors
 
+### Driver Has Stricter Type Declarations
+
+Check the [`Driver` interface](https://github.com/AgencyPMG/Queue/blob/master/src/Driver.php)
+for the updated method signatures.
+
 ### `assureSerializer` was renamed in `AbstractPersistanceDriver`
 
 ```php

--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -25,10 +25,15 @@ $serializer = NativeSerializer::fromSigningKey('secretKey');
 
 ## For Driver Authors
 
-### Driver Has Stricter Type Declarations
+### `Driver` Has Stricter Type Declarations
 
 Check the [`Driver` interface](https://github.com/AgencyPMG/Queue/blob/master/src/Driver.php)
 for the updated method signatures.
+
+### `Driver::release` was Added
+
+This is a method that should skip the retry system for the given
+envelope/message and put it back into a ready state immediately.
 
 ### `assureSerializer` was renamed in `AbstractPersistanceDriver`
 

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -79,4 +79,17 @@ interface Driver
      * @return  void
      */
     public function fail(string $queueName, Envelope $envelope);
+
+    /**
+     * Release a message back to a ready state. This is used by the consumer
+     * when it skips the retry system. This may happen if the consumer receives
+     * a signal and has to exit early.
+     *
+     * @param $queueName The queue from which the message came
+     * @param $envelope The message to release, should be the same instance
+     *        returned from `dequeue`
+     * @throws Exception\DriverError if something goes wrong
+     * @return void
+     */
+    public function release(string $queueName, Envelope $envelope);
 }

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -36,7 +36,7 @@ interface Driver
      * @throws  Exception\DriverError when something goes wrong
      * @return  Envelope An envelop representing the message in the queue.
      */
-    public function enqueue($queueName, Message $message);
+    public function enqueue(string $queueName, Message $message) : Envelope;
 
     /**
      * Pull a message out of the queue.
@@ -45,7 +45,7 @@ interface Driver
      * @throws  Exception\DriverError when something goes wrong
      * @return  Envelope|null An envelope if a message is found, null otherwise
      */
-    public function dequeue($queueName);
+    public function dequeue(string $queueName);
 
     /**
      * Acknowledge a message as complete.
@@ -56,7 +56,7 @@ interface Driver
      * @throws  Exception\DriverError when something goes wrong
      * @return  void
      */
-    public function ack($queueName, Envelope $envelope);
+    public function ack(string $queueName, Envelope $envelope);
 
     /**
      * Retry a job -- put it back in the queue for retrying.
@@ -67,7 +67,7 @@ interface Driver
      * @throws  Exception\DriverError when something goes wrong
      * @return  Envelope The new envelope for the retried job.
      */
-    public function retry($queueName, Envelope $envelope);
+    public function retry(string $queueName, Envelope $envelope) : Envelope;
 
     /**
      * Fail a job -- this called when no more retries can be attempted.
@@ -76,7 +76,7 @@ interface Driver
      * @param   $envelope The message envelope -- should be the same instance
      *          returned from `dequeue`
      * @throws  Exception\DriverError when something goes wrong
-     * @return  Envelope The new envelope for the retried job.
+     * @return  void
      */
-    public function fail($queueName, Envelope $envelope);
+    public function fail(string $queueName, Envelope $envelope);
 }

--- a/src/Driver/AbstractPersistanceDriver.php
+++ b/src/Driver/AbstractPersistanceDriver.php
@@ -60,15 +60,15 @@ abstract class AbstractPersistanceDriver implements \PMG\Queue\Driver
 
     protected function serialize(Envelope $env)
     {
-        return $this->assureSerializer()->serialize($env);
+        return $this->ensureSerializer()->serialize($env);
     }
 
     protected function unserialize($data)
     {
-        return $this->assureSerializer()->unserialize($data);
+        return $this->ensureSerializer()->unserialize($data);
     }
 
-    protected function assureSerializer()
+    protected function ensureSerializer()
     {
         if (!$this->serializer) {
             throw new \RuntimeException(sprintf(

--- a/src/Driver/MemoryDriver.php
+++ b/src/Driver/MemoryDriver.php
@@ -32,7 +32,7 @@ final class MemoryDriver implements \PMG\Queue\Driver
     /**
      * {@inheritdoc}
      */
-    public function enqueue($queueName, Message $message)
+    public function enqueue(string $queueName, Message $message) : Envelope
     {
         $e = new DefaultEnvelope($message);
         $this->enqueueEnvelope($queueName, $e);
@@ -42,7 +42,7 @@ final class MemoryDriver implements \PMG\Queue\Driver
     /**
      * {@inheritdoc}
      */
-    public function dequeue($queueName)
+    public function dequeue(string $queueName)
     {
         try{
             return $this->getQueue($queueName)->dequeue();
@@ -54,7 +54,7 @@ final class MemoryDriver implements \PMG\Queue\Driver
     /**
      * {@inheritdoc}
      */
-    public function ack($queueName, Envelope $envelope)
+    public function ack(string $queueName, Envelope $envelope)
     {
         // noop
     }
@@ -62,7 +62,7 @@ final class MemoryDriver implements \PMG\Queue\Driver
     /**
      * {@inheritdoc}
      */
-    public function retry($queueName, Envelope $envelope)
+    public function retry(string $queueName, Envelope $envelope) : Envelope
     {
         $e = $envelope->retry();
         $this->enqueueEnvelope($queueName, $e);
@@ -72,12 +72,12 @@ final class MemoryDriver implements \PMG\Queue\Driver
     /**
      * {@inheritdoc}
      */
-    public function fail($queueName, Envelope $envelope)
+    public function fail(string $queueName, Envelope $envelope)
     {
         // noop
     }
 
-    private function enqueueEnvelope($queueName, Envelope $envelope)
+    private function enqueueEnvelope(string $queueName, Envelope $envelope)
     {
         $this->getQueue($queueName)->enqueue($envelope);
     }

--- a/src/Driver/MemoryDriver.php
+++ b/src/Driver/MemoryDriver.php
@@ -77,12 +77,20 @@ final class MemoryDriver implements \PMG\Queue\Driver
         // noop
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function release(string $queueName, Envelope $envelope)
+    {
+        $this->enqueueEnvelope($queueName, $envelope);
+    }
+
     private function enqueueEnvelope(string $queueName, Envelope $envelope)
     {
         $this->getQueue($queueName)->enqueue($envelope);
     }
 
-    private function getQueue($queueName)
+    private function getQueue(string $queueName)
     {
         if (!isset($this->queues[$queueName])) {
             $this->queues[$queueName] = new \SplQueue();

--- a/test/unit/Driver/MemoryDriverTest.php
+++ b/test/unit/Driver/MemoryDriverTest.php
@@ -41,6 +41,20 @@ class MemoryDriverTest extends \PMG\Queue\UnitTestCase
         $this->assertSame($m, $e->unwrap());
     }
 
+    public function testMessagesCanBeEnqueuedDequeuedAndReleased()
+    {
+        $m = new SimpleMessage('test');
+        $this->assertInstanceOf(Envelope::class, $this->driver->enqueue(self::Q, $m));
+
+        $e = $this->driver->dequeue(self::Q);
+        $this->assertSame($m, $e->unwrap());
+
+        $this->driver->release(self::Q, $e);
+
+        $e2 = $this->driver->dequeue(self::Q);
+        $this->assertSame($e, $e2);
+    }
+
     protected function setUp()
     {
         $this->driver = new MemoryDriver();


### PR DESCRIPTION
New method in `Driver` for releasing a message (skipping the retry system, putting it back in a ready state).

This also updates `Driver` with some new typehints.

Closes #42 