### PR TITLE
Fix a Typo in DefaultConsumer

### DIFF
--- a/src/DefaultConsumer.php
+++ b/src/DefaultConsumer.php
@@ -97,7 +97,7 @@ class DefaultConsumer extends AbstractConsumer
     public function stop(int $code=null)
     {
         if ($this->currentPromise) {
-            $this->currrentPromise->cancel();
+            $this->currentPromise->cancel();
         }
         parent::stop($code);
     }

--- a/test/integration/ForkingHandlerIntTest.php
+++ b/test/integration/ForkingHandlerIntTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+/**
+ * @requires function pcntl_async_signals
+ */
+class ForkingHandlerIntTest extends IntegrationTestCase
+{
+    private $driver, $producer;
+
+    /**
+     * @group slow
+     */
+    public function testMessagesCanBeCancelledWhileInProgressFromConsumerStop()
+    {
+        $this->producer->send(new SimpleMessage('TestMessage'));
+        $consumer = $this->createConsumer(function () {
+            sleep(100);
+        });
+        pcntl_signal(SIGALRM, function () use ($consumer) {
+            $consumer->stop(1);
+        });
+        pcntl_alarm(5);
+
+        $exitCode = $consumer->run('q');
+
+        $this->assertSame(1, $exitCode);
+    }
+
+    protected function setUp()
+    {
+        pcntl_signal(SIGALRM, SIG_DFL);
+        pcntl_async_signals(true);
+        $this->driver = new Driver\MemoryDriver();
+
+        $this->producer = new DefaultProducer(
+            $this->driver,
+            new Router\SimpleRouter('q')
+        );
+    }
+
+    private function createConsumer(callable $handler) : DefaultConsumer
+    {
+        return new DefaultConsumer(
+            $this->driver,
+            new Handler\PcntlForkingHandler(new Handler\CallableHandler($handler)),
+            new Retry\NeverSpec()
+        );
+    }
+}

--- a/test/unit/Handler/PcntlForkingHandlerTest.php
+++ b/test/unit/Handler/PcntlForkingHandlerTest.php
@@ -110,6 +110,9 @@ class PcntlForkingHandlerTest extends \PMG\Queue\UnitTestCase
         $handler->handle($this->message);
     }
 
+    /**
+     * @group slow
+     */
     public function testHandlerPromisesCanBeCancelled()
     {
         $this->expectException(ForkedProcessCancelled::class);


### PR DESCRIPTION
And also add an integration test with the `PcntlForkingHandler` to
verify that this fix works (and never happens again).