### PR TITLE
Add New Message Lifecycles Geared Towards Composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-n/a
+- Deprecated `PMG\Queue\NullLifecycle`, use `PMG\Queue\Lifecycle\NullLifecycle`
+  instead.
 
 ### Fixed
 

--- a/docs/consumers.rst
+++ b/docs/consumers.rst
@@ -163,7 +163,7 @@ sending a notification when a message fails and will not be retried.
 
     <?php
 
-    use PMG\Queue\NullLifecycle;
+    use PMG\Queue\Lifecycle\NullLifecycle;
     use App\Notifications\Notifier;
     use App\Notifications\Notification;
 

--- a/docs/consumers.rst
+++ b/docs/consumers.rst
@@ -207,6 +207,80 @@ name as a constructor argument.
 We've found at PMG that most times queue name is a detail that simply does not
 matter to the application itself. It's just a way to distribute work.
 
+Provided Message Lifecycles
+"""""""""""""""""""""""""""
+
+A ``NullLifecycle``, mentioned above, that does nothing. This makes a convenient
+base class to extend and implement what methods your application requires.
+
+Additionally there are a few other provided ``MessageLifecycle`` implementations.
+
+``DelegatingLifecycle`` proxies to multiple child lifecycles. Use this to compose
+other lifecycles together. In the example below, both ``NotifyingLifecycle`` and
+``SomeOtherLifecycle`` would be called for each stage through which the message
+moves.
+
+.. code-block:: php
+
+    <?php
+
+    use PMG\Queue\Lifecycle\DelegatingLifecycle;
+
+    $lifecycle = new DelegatingLifecycle(
+        new NotifyingLifecycle(/* ... */), // see above
+        new SomeOtherLifecycle()
+    );
+
+    // Or create from an array
+    $lifecycle = DelegatingLifecycle::fromArray([
+        new NotifyingLifecycle(/* ... */),
+        new SomeOtherLifecycle(),
+    ]);
+
+``MappingLifecycle`` proxies to other lifecycles based on the incoming message
+name. Use this if specific ``MessageLifecycle`` implementations need to fire
+for specific messages. In the example below ``NotifyingLifecycle`` would track
+``messageA`` through its lifecycle and ``SomeOtherLifecycle`` would track
+``messageB``. Any other message would fallback to ``FallbackLifecycle``.
+
+.. code-block:: php
+
+    <?php
+
+    use PMG\Queue\Lifecycle\MappingLifecycle;
+
+    // can use an array or `ArrayAccess` implementation here
+    $lifecycle = new MappingLifecycle([
+        'messageA' => new NotifyingLifecycle(/* ... */), 
+        'messageB' => new SomeOtherLifecycle(),
+    ], new FallbackLifecycle());
+
+    // or omit the fallback and it will default to `NullLifecycle`
+    // and do nothing.
+    $lifecycle = new MappingLifecycle([
+        'messageA' => new NotifyingLifecycle(/* ... */), 
+        'messageB' => new SomeOtherLifecycle(),
+    ]);
+
+These two implementations could be combined as well.
+
+.. code-block:: php
+
+    <?php
+
+    use PMG\Queue\Lifecycle\DelegatingLifecycle;
+    use PMG\Queue\Lifecycle\MappingLifecycle;
+
+    $lifecycle = new DelegatingLifecycle(
+        new FooLifecycle(),
+        new MappingLifecycle([
+            'messageA' => new DelegatingLifecycle(
+                new BarLifecycle(),
+                new BazLifecycle()
+            ),
+        ])
+    );
+
 Build Custom Consumers
 ----------------------
 

--- a/src/Lifecycle/DelegatingLifecycle.php
+++ b/src/Lifecycle/DelegatingLifecycle.php
@@ -88,7 +88,7 @@ final class DelegatingLifecycle implements MessageLifecycle, \Countable
         return count($this->lifecycles);
     }
 
-    private function apply(callable $fn) : void
+    private function apply(callable $fn)
     {
         foreach ($this->lifecycles as $lifecycle) {
             $fn($lifecycle);

--- a/src/Lifecycle/DelegatingLifecycle.php
+++ b/src/Lifecycle/DelegatingLifecycle.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Lifecycle;
+
+
+use PMG\Queue\Consumer;
+use PMG\Queue\Message;
+use PMG\Queue\MessageLifecycle;
+
+/**
+ * A `MessageLifecycle` implementation that delegates to other lifecycles.
+ *
+ * @since 4.2
+ */
+final class DelegatingLifecycle implements MessageLifecycle, \Countable
+{
+    /**
+     * @var MessageLifecycle[]
+     */
+    private $lifecycles;
+
+    public function __construct(MessageLifecycle ...$lifecycles)
+    {
+        $this->lifecycles = $lifecycles;
+    }
+
+    public static function fromArray(array $lifecycles) : self
+    {
+        return new self(...$lifecycles);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function starting(Message $message, Consumer $consumer)
+    {
+        $this->apply(function (MessageLifecycle $ml) use ($message, $consumer) {
+            $ml->starting($message, $consumer);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completed(Message $message, Consumer $consumer)
+    {
+        $this->apply(function (MessageLifecycle $ml) use ($message, $consumer) {
+            $ml->completed($message, $consumer);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function failed(Message $message, Consumer $consumer, bool $isRetrying)
+    {
+        $this->apply(function (MessageLifecycle $ml) use ($message, $consumer, $isRetrying) {
+            $ml->failed($message, $consumer, $isRetrying);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function succeeded(Message $message, Consumer $consumer)
+    {
+        $this->apply(function (MessageLifecycle $ml) use ($message, $consumer) {
+            $ml->succeeded($message, $consumer);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->lifecycles);
+    }
+
+    private function apply(callable $fn) : void
+    {
+        foreach ($this->lifecycles as $lifecycle) {
+            $fn($lifecycle);
+        }
+    }
+}

--- a/src/Lifecycle/MappingLifecycle.php
+++ b/src/Lifecycle/MappingLifecycle.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Lifecycle;
+
+
+use PMG\Queue\Consumer;
+use PMG\Queue\Message;
+use PMG\Queue\MessageLifecycle;
+use PMG\Queue\Exception\InvalidArgumentException;
+
+/**
+ * A `MessageLifecycle` implementation that applies other lifecycles based on
+ * a apping and the incoming message name.
+ *
+ * @since 4.2
+ */
+final class MappingLifecycle implements MessageLifecycle
+{
+    /**
+     * A mapping of message names to lifecycles. [$messageName => $lifecycle]
+     *
+     * @var array|ArrayAccess
+     */
+    private $mapping;
+
+    /**
+     * @var MessageLifecycle
+     */
+    private $fallback;
+
+    /**
+     * @param array|ArrayAccess $mapping the message mapping
+     * @param $fallback The message lifecycle to which unmatches messages will be applied
+     * @throws InvalidArgumentException if $mapping is a bad type
+     */
+    public function __construct($mapping, ?MessageLifecycle $fallback=null)
+    {
+        if (!is_array($mapping) && !$mapping instanceof \ArrayAccess) {
+            throw new InvalidArgumentException(sprintf(
+                '$mapping must be an array or ArrayAccess implementation, got "%s"',
+                is_object($mapping) ? get_class($mapping) : gettype($mapping)
+            ));
+        }
+
+        $this->mapping = $mapping;
+        $this->fallback = $fallback ?? new NullLifecycle();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function starting(Message $message, Consumer $consumer)
+    {
+        $this->lifecycleFor($message)->starting($message, $consumer);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completed(Message $message, Consumer $consumer)
+    {
+        $this->lifecycleFor($message)->completed($message, $consumer);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function failed(Message $message, Consumer $consumer, bool $isRetrying)
+    {
+        $this->lifecycleFor($message)->failed($message, $consumer, $isRetrying);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function succeeded(Message $message, Consumer $consumer)
+    {
+        $this->lifecycleFor($message)->succeeded($message, $consumer);
+    }
+
+    /**
+     * Check whether or not the message has a lifecycle.
+     * 
+     * @param $messageName the message name to check
+     * @return true if a message lifecycle exists for the message
+     */
+    public function has(string $messageName) : bool
+    {
+        return isset($this->mapping[$messageName]);
+    }
+
+    private function lifecycleFor(Message $message) : MessageLifecycle
+    {
+        $name = $message->getName();
+        return $this->has($name) ? $this->mapping[$name] : $this->fallback;
+    }
+}

--- a/src/Lifecycle/MappingLifecycle.php
+++ b/src/Lifecycle/MappingLifecycle.php
@@ -44,7 +44,7 @@ final class MappingLifecycle implements MessageLifecycle
      * @param $fallback The message lifecycle to which unmatches messages will be applied
      * @throws InvalidArgumentException if $mapping is a bad type
      */
-    public function __construct($mapping, ?MessageLifecycle $fallback=null)
+    public function __construct($mapping, MessageLifecycle $fallback=null)
     {
         if (!is_array($mapping) && !$mapping instanceof \ArrayAccess) {
             throw new InvalidArgumentException(sprintf(

--- a/src/Lifecycle/NullLifecycle.php
+++ b/src/Lifecycle/NullLifecycle.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Lifecycle;
+
+use PMG\Queue\Consumer;
+use PMG\Queue\Message;
+use PMG\Queue\MessageLifecycle;
+
+/**
+ * A `MessageLifecycle` implementation that does nothing.
+ *
+ * This is also useful to extend in your own implementation if you only care
+ * about certain events.
+ *
+ * @since 4.0
+ */
+class NullLifecycle implements MessageLifecycle
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function starting(Message $message, Consumer $consumer)
+    {
+        // noop
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function completed(Message $message, Consumer $consumer)
+    {
+        // noop
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function failed(Message $message, Consumer $consumer, bool $isRetrying)
+    {
+        // noop
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function succeeded(Message $message, Consumer $consumer)
+    {
+        // noop
+    }
+}

--- a/src/NullLifecycle.php
+++ b/src/NullLifecycle.php
@@ -13,45 +13,12 @@
 
 namespace PMG\Queue;
 
-/**
- * A `MessageLifecycle` implementation that does nothing.
- *
- * This is also useful to extend in your own implementation if you only care
- * about certain events.
- *
- * @since 4.0
- */
-class NullLifecycle implements MessageLifecycle
-{
-    /**
-     * {@inheritdoc}
-     */
-    public function starting(Message $message, Consumer $consumer)
-    {
-        // noop
-    }
+use PMG\Queue\Lifecycle\NullLifecycle;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function completed(Message $message, Consumer $consumer)
-    {
-        // noop
-    }
+class_alias(NullLifecycle::class, __NAMESPACE__.'\\NullLifecycle');
 
-    /**
-     * {@inheritdoc}
-     */
-    public function failed(Message $message, Consumer $consumer, bool $isRetrying)
-    {
-        // noop
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function succeeded(Message $message, Consumer $consumer)
-    {
-        // noop
-    }
-}
+@trigger_error(sprintf(
+    'The %s\\NullLifecycle class is deprecated, use %s instead',
+    __NAMESPACE__,
+    NullLifecycle::class
+), E_USER_DEPRECATED);

--- a/test/unit/Lifecycle/DelegatingLifecycleTest.php
+++ b/test/unit/Lifecycle/DelegatingLifecycleTest.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Lifecycle;
+
+class DelegatingLifecycleTest extends LifecycleTestCase
+{
+    public static function methods() : array
+    {
+        return [
+            ['starting'],
+            ['completed'],
+            ['failed', true],
+            ['succeeded'],
+        ];
+    }
+
+    /**
+     * @dataProvider methods
+     */
+    public function testLifecycleCallsChildLifecyclesWithProvidedArguments(string $method, ...$additional)
+    {
+        $lc = $this->mockLifecycle();
+        $lc->expects($this->once())
+            ->method($method)
+            ->with($this->isMessage(), $this->isConsumer(), ...$additional);
+
+        $dl = new DelegatingLifecycle($lc);
+
+        call_user_func([$dl, $method], $this->message, $this->consumer, ...$additional);
+    }
+
+    public function testDelegatingLifecyclesCanBeCreatedFromAnArray()
+    {
+        $dl = DelegatingLifecycle::fromArray([
+            $this->mockLifecycle(),
+            $this->mockLifecycle(),
+            $this->mockLifecycle(),
+        ]);
+
+        $this->assertCount(3, $dl, 'should have three child lifecycles');
+    }
+}

--- a/test/unit/Lifecycle/LifecycleTestCase.php
+++ b/test/unit/Lifecycle/LifecycleTestCase.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Lifecycle;
+
+use PMG\Queue\MessageLifecycle;
+use PMG\Queue\Consumer;
+use PMG\Queue\SimpleMessage;
+
+abstract class LifecycleTestCase extends \PMG\Queue\UnitTestCase
+{
+    protected $consumer, $message;
+
+    protected function setUp()
+    {
+        $this->consumer = $this->createMock(Consumer::class);
+        $this->message = new SimpleMessage('example');
+    }
+
+    protected function mockLifecycle() : MessageLifecycle
+    {
+        return $this->createMock(MessageLifecycle::class);
+    }
+
+    protected function isConsumer()
+    {
+        return $this->identicalTo($this->consumer);
+    }
+
+    protected function isMessage()
+    {
+        return $this->identicalTo($this->message);
+    }
+}

--- a/test/unit/Lifecycle/MappingLifecycleTest.php
+++ b/test/unit/Lifecycle/MappingLifecycleTest.php
@@ -1,0 +1,123 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue\Lifecycle;
+
+use PMG\Queue\SimpleMessage;
+use PMG\Queue\Exception\InvalidArgumentException;
+
+class MappingLifecycleTest extends LifecycleTestCase
+{
+    private $child, $fallback, $lifecycle;
+
+    public static function badMappings() : array
+    {
+        return [
+            ['one'],
+            [1],
+            [true],
+            [null],
+            [new \stdClass],
+        ];
+    }
+
+    /**
+     * @dataProvider badMappings
+     */
+    public function testLifecyclesCannotBeCreatedWithNonArrayishObjects($mapping)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new MappingLifecycle($mapping);
+    }
+
+    public function validMappings() : array
+    {
+        return [
+            [['one' => new NullLifecycle()]],
+            [new \ArrayObject(['one' => new NullLifecycle()])],
+        ];
+    }
+
+    /**
+     * @dataProvider validMappings
+     */
+    public function testLifecycleCanBeCreatedFromArrayishObject($mapping)
+    {
+        $lc = new MappingLifecycle($mapping);
+
+        $this->assertTrue($lc->has('one'));
+        $this->assertFalse($lc->has('two'));
+    }
+
+    public static function methods() : array
+    {
+        return [
+            ['starting'],
+            ['completed'],
+            ['failed', true],
+            ['succeeded'],
+        ];
+    }
+
+    /**
+     * @dataProvider methods
+     */
+    public function testLifecycleCallsFallbackIfMessageIsNotInMapping(string $method, ...$additional)
+    {
+        $message = new SimpleMessage('noope');
+        $this->child->expects($this->never())
+            ->method($method);
+        $this->fallback->expects($this->once())
+            ->method($method)
+            ->with($this->identicalTo($message), $this->isConsumer(), ...$additional);
+
+        call_user_func([$this->lifecycle, $method], $message, $this->consumer, ...$additional);
+    }
+
+    /**
+     * @dataProvider methods
+     */
+    public function testLifecycleCanBeCreatedWithoutAFallbackAndStillWorksWithUnmappedMessages(string $method, ...$additional)
+    {
+        $message = new SimpleMessage('noope');
+        $this->child->expects($this->never())
+            ->method($method);
+        $lc = new MappingLifecycle([
+            $this->message->getName() => $this->child,
+        ]);
+    
+        call_user_func([$lc, $method], $message, $this->consumer, ...$additional);
+    }
+
+    /**
+     * @dataProvider methods
+     */
+    public function testLifecycleCallsChildLifecycleIfMappingHasMessage(string $method, ...$additional)
+    {
+        $this->child->expects($this->once())
+            ->method($method)
+            ->with($this->isMessage(), $this->isConsumer(), ...$additional);
+
+        call_user_func([$this->lifecycle, $method], $this->message, $this->consumer, ...$additional);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->child = $this->mockLifecycle();
+        $this->fallback = $this->mockLifecycle();
+        $this->lifecycle = new MappingLifecycle([
+            $this->message->getName() => $this->child,
+        ], $this->fallback);
+    }
+}


### PR DESCRIPTION
- `DelegatingLifecycle` that just calls any other lifecycles passed to its constructor
- `MappingLifecycle` to call specific lifecycles per message

PMG needs these features for an application and it makes sense to provide them here in the core.