### PR TITLE
Drop Support for PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-    - 7.0
     - 7.1
+    - 7.2
 
 notifications:
     email: false

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0",
-        "paragonie/sodium_compat": "^0.7"
+        "paragonie/sodium_compat": "~1.4"
     },
     "suggest": {
         "pmg/queue-pheanstalk": "Power pmg/queue with Beanstalkd"

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         { "name": "Christopher Davis", "email": "chris@pmg.com" }
     ],
     "require": {
-        "php": "~7.0",
+        "php": "~7.1",
         "psr/log": "~1.0",
         "guzzlehttp/promises": "~1.3"
 


### PR DESCRIPTION
Only 7.1+ now.

Closes #72 

Closes #71 