### PR TITLE
Add a Specific Method for Retrying Messages in MessageLifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ n/a
 
 - A new `MessageLifecycle::retrying` method was added that gets called whenever
   a message fails and is retrying.
+- `PMG\Queue\Lifecycle\DelegatingLifecycle` has a new named constructor:
+  `fromIterable`. This uses PHP 7.1's `iterable` pseudo type.
+
+### Deprecations
+
+- `PMG\Queue\Lifecycle\DelegatingLifecycle::fromArray`. Use `fromIterable`
+  instead.
 
 ## 4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 4.NEXT (Unreleased)
+## 5.NEXT (Unreleased)
 
 ### Changed
 
-n/a
+- `MessageLifecycle::failed` no longer has an `$isRetrying` argument, instead
+  `MessageLifecycyle::retrying` will be called instead.
 
 ### Fixed
 
@@ -15,7 +16,8 @@ n/a
 
 ### Added
 
-n/a
+- A new `MessageLifecycle::retrying` method was added that gets called whenever
+  a message fails and is retrying.
 
 ## 4.2.0
 

--- a/docs/consumers.rst
+++ b/docs/consumers.rst
@@ -176,14 +176,12 @@ sending a notification when a message fails and will not be retried.
 
         // constructor, etc
 
-        public function failed(Message $message, Consumer $consumer, bool $isRetrying)
+        public function failed(Message $message, Consumer $consumer)
         {
-            if (!$isRetrying) {
-                $this->notifier->send(new Notification(sprintf(
-                    '%s message failed',
-                    $message->getName()
-                )));
-            }
+            $this->notifier->send(new Notification(sprintf(
+                '%s message failed',
+                $message->getName()
+            )));
         }
     }
 

--- a/src/DefaultConsumer.php
+++ b/src/DefaultConsumer.php
@@ -84,8 +84,10 @@ class DefaultConsumer extends AbstractConsumer
 
         if ($succeeded) {
             $lifecycle->succeeded($message, $this);
+        } elseif ($willRetry) {
+            $lifecycle->retrying($message, $this);
         } else {
-            $lifecycle->failed($message, $this, $willRetry);
+            $lifecycle->failed($message, $this);
         }
 
         return $succeeded;

--- a/src/Lifecycle/DelegatingLifecycle.php
+++ b/src/Lifecycle/DelegatingLifecycle.php
@@ -38,7 +38,7 @@ final class DelegatingLifecycle implements MessageLifecycle, \Countable
     public static function fromArray(array $lifecycles) : self
     {
         @trigger_error(sprintf(
-            '%s deprecated as of version 5.0 and will be removed in 6.0, use %s::fromIterable instead',
+            '%s is deprecated as of version 5.0 and will be removed in 6.0, use %s::fromIterable instead',
             __METHOD__,
             __CLASS__
         ), E_USER_DEPRECATED);

--- a/src/Lifecycle/DelegatingLifecycle.php
+++ b/src/Lifecycle/DelegatingLifecycle.php
@@ -63,10 +63,20 @@ final class DelegatingLifecycle implements MessageLifecycle, \Countable
     /**
      * {@inheritdoc}
      */
-    public function failed(Message $message, Consumer $consumer, bool $isRetrying)
+    public function retrying(Message $message, Consumer $consumer)
     {
-        $this->apply(function (MessageLifecycle $ml) use ($message, $consumer, $isRetrying) {
-            $ml->failed($message, $consumer, $isRetrying);
+        $this->apply(function (MessageLifecycle $ml) use ($message, $consumer) {
+            $ml->retrying($message, $consumer);
+        });
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function failed(Message $message, Consumer $consumer)
+    {
+        $this->apply(function (MessageLifecycle $ml) use ($message, $consumer) {
+            $ml->failed($message, $consumer);
         });
     }
 

--- a/src/Lifecycle/DelegatingLifecycle.php
+++ b/src/Lifecycle/DelegatingLifecycle.php
@@ -37,6 +37,12 @@ final class DelegatingLifecycle implements MessageLifecycle, \Countable
 
     public static function fromArray(array $lifecycles) : self
     {
+        @trigger_error(sprintf(
+            '%s deprecated as of version 5.0 and will be removed in 6.0, use %s::fromIterable instead',
+            __METHOD__,
+            __CLASS__
+        ), E_USER_DEPRECATED);
+
         return new self(...$lifecycles);
     }
 

--- a/src/Lifecycle/DelegatingLifecycle.php
+++ b/src/Lifecycle/DelegatingLifecycle.php
@@ -40,6 +40,11 @@ final class DelegatingLifecycle implements MessageLifecycle, \Countable
         return new self(...$lifecycles);
     }
 
+    public static function fromIterable(iterable $lifecycles) : self
+    {
+        return new self(...$lifecycles);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Lifecycle/MappingLifecycle.php
+++ b/src/Lifecycle/MappingLifecycle.php
@@ -76,9 +76,17 @@ final class MappingLifecycle implements MessageLifecycle
     /**
      * {@inheritdoc}
      */
-    public function failed(Message $message, Consumer $consumer, bool $isRetrying)
+    public function retrying(Message $message, Consumer $consumer)
     {
-        $this->lifecycleFor($message)->failed($message, $consumer, $isRetrying);
+        $this->lifecycleFor($message)->retrying($message, $consumer);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function failed(Message $message, Consumer $consumer)
+    {
+        $this->lifecycleFor($message)->failed($message, $consumer);
     }
 
     /**

--- a/src/Lifecycle/NullLifecycle.php
+++ b/src/Lifecycle/NullLifecycle.php
@@ -46,7 +46,15 @@ class NullLifecycle implements MessageLifecycle
     /**
      * {@inheritdoc}
      */
-    public function failed(Message $message, Consumer $consumer, bool $isRetrying)
+    public function retrying(Message $message, Consumer $consumer)
+    {
+        // noop
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function failed(Message $message, Consumer $consumer)
     {
         // noop
     }

--- a/src/MessageLifecycle.php
+++ b/src/MessageLifecycle.php
@@ -43,7 +43,19 @@ interface MessageLifecycle
     public function completed(Message $message, Consumer $consumer);
 
     /**
-     * Called when a message errors.
+     * Called when a message failed and is retrying.
+     *
+     * No details about the error are provided because the consumer may not even
+     * have them.
+     *
+     * @param $message The message that errored and is retrying
+     * @param $consumer The consumer that did the work
+     * @return void
+     */
+    public function retrying(Message $message, Consumer $consumer);
+
+    /**
+     * Called when a message failed.
      *
      * No details about the error are provided here because consumers, specifically
      * the default consumer implementation may not have those details. For instance,
@@ -52,10 +64,9 @@ interface MessageLifecycle
      *
      * @param $message The message that errored
      * @param $consumer The consumer that did the work
-     * @param $isRetrying Whether the message is being retried.
      * @return void
      */
-    public function failed(Message $message, Consumer $consumer, bool $isRetrying);
+    public function failed(Message $message, Consumer $consumer);
 
     /**
      * Called when message processing was successful.

--- a/test/unit/Lifecycle/DelegatingLifecycleTest.php
+++ b/test/unit/Lifecycle/DelegatingLifecycleTest.php
@@ -13,6 +13,9 @@
 
 namespace PMG\Queue\Lifecycle;
 
+/**
+ * @group lifecycles
+ */
 class DelegatingLifecycleTest extends LifecycleTestCase
 {
     public static function methods() : array
@@ -48,6 +51,17 @@ class DelegatingLifecycleTest extends LifecycleTestCase
             $this->mockLifecycle(),
             $this->mockLifecycle(),
         ]);
+
+        $this->assertCount(3, $dl, 'should have three child lifecycles');
+    }
+
+    public function testDelegatingLifecyclesCanBeCreatedFromIterables()
+    {
+        $dl = DelegatingLifecycle::fromIterable((function () {
+            foreach (range(1, 3) as $i) {
+                yield $this->mockLifecycle();
+            }
+        })());
 
         $this->assertCount(3, $dl, 'should have three child lifecycles');
     }

--- a/test/unit/Lifecycle/DelegatingLifecycleTest.php
+++ b/test/unit/Lifecycle/DelegatingLifecycleTest.php
@@ -20,7 +20,8 @@ class DelegatingLifecycleTest extends LifecycleTestCase
         return [
             ['starting'],
             ['completed'],
-            ['failed', true],
+            ['retrying'],
+            ['failed'],
             ['succeeded'],
         ];
     }
@@ -28,16 +29,16 @@ class DelegatingLifecycleTest extends LifecycleTestCase
     /**
      * @dataProvider methods
      */
-    public function testLifecycleCallsChildLifecyclesWithProvidedArguments(string $method, ...$additional)
+    public function testLifecycleCallsChildLifecyclesWithProvidedArguments(string $method)
     {
         $lc = $this->mockLifecycle();
         $lc->expects($this->once())
             ->method($method)
-            ->with($this->isMessage(), $this->isConsumer(), ...$additional);
+            ->with($this->isMessage(), $this->isConsumer());
 
         $dl = new DelegatingLifecycle($lc);
 
-        call_user_func([$dl, $method], $this->message, $this->consumer, ...$additional);
+        call_user_func([$dl, $method], $this->message, $this->consumer);
     }
 
     public function testDelegatingLifecyclesCanBeCreatedFromAnArray()

--- a/test/unit/Lifecycle/MappingLifecycleTest.php
+++ b/test/unit/Lifecycle/MappingLifecycleTest.php
@@ -16,6 +16,9 @@ namespace PMG\Queue\Lifecycle;
 use PMG\Queue\SimpleMessage;
 use PMG\Queue\Exception\InvalidArgumentException;
 
+/**
+ * @group lifecycles
+ */
 class MappingLifecycleTest extends LifecycleTestCase
 {
     private $child, $fallback, $lifecycle;
@@ -64,7 +67,8 @@ class MappingLifecycleTest extends LifecycleTestCase
         return [
             ['starting'],
             ['completed'],
-            ['failed', true],
+            ['retrying'],
+            ['failed'],
             ['succeeded'],
         ];
     }
@@ -72,22 +76,22 @@ class MappingLifecycleTest extends LifecycleTestCase
     /**
      * @dataProvider methods
      */
-    public function testLifecycleCallsFallbackIfMessageIsNotInMapping(string $method, ...$additional)
+    public function testLifecycleCallsFallbackIfMessageIsNotInMapping(string $method)
     {
         $message = new SimpleMessage('noope');
         $this->child->expects($this->never())
             ->method($method);
         $this->fallback->expects($this->once())
             ->method($method)
-            ->with($this->identicalTo($message), $this->isConsumer(), ...$additional);
+            ->with($this->identicalTo($message), $this->isConsumer());
 
-        call_user_func([$this->lifecycle, $method], $message, $this->consumer, ...$additional);
+        call_user_func([$this->lifecycle, $method], $message, $this->consumer);
     }
 
     /**
      * @dataProvider methods
      */
-    public function testLifecycleCanBeCreatedWithoutAFallbackAndStillWorksWithUnmappedMessages(string $method, ...$additional)
+    public function testLifecycleCanBeCreatedWithoutAFallbackAndStillWorksWithUnmappedMessages(string $method)
     {
         $message = new SimpleMessage('noope');
         $this->child->expects($this->never())
@@ -96,19 +100,19 @@ class MappingLifecycleTest extends LifecycleTestCase
             $this->message->getName() => $this->child,
         ]);
     
-        call_user_func([$lc, $method], $message, $this->consumer, ...$additional);
+        call_user_func([$lc, $method], $message, $this->consumer);
     }
 
     /**
      * @dataProvider methods
      */
-    public function testLifecycleCallsChildLifecycleIfMappingHasMessage(string $method, ...$additional)
+    public function testLifecycleCallsChildLifecycleIfMappingHasMessage(string $method)
     {
         $this->child->expects($this->once())
             ->method($method)
-            ->with($this->isMessage(), $this->isConsumer(), ...$additional);
+            ->with($this->isMessage(), $this->isConsumer());
 
-        call_user_func([$this->lifecycle, $method], $this->message, $this->consumer, ...$additional);
+        call_user_func([$this->lifecycle, $method], $this->message, $this->consumer);
     }
 
     protected function setUp()


### PR DESCRIPTION
Previously this was a boolean [flag argument](https://martinfowler.com/bliki/FlagArgument.html) saying whether the message was retrying or not in `MessageLifecycled::failed`.

This is bad for the reasons that flag arguments are generally bad, but also this clarifying intent quite a bit. Has a message really failed if it's being retried? I'd say no.

Closes #77 