### PR TITLE
Rework Message Names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `Message` interface no longer has a `getName` method.
   Instead the *name* of a message is its fully qualified class name. Should the
   old behavior still be desired, implement `PMG\Queue\NamedMessage` instead.
+- The `PMG\Queue\MessageTrait` has been deprecated. The behavior it provided (using
+  the fully qualified class name as the message name) is now the default.
 
 ### Fixed
 
@@ -28,8 +30,6 @@ n/a
 
 ### Removed
 
-- The `PMG\Queue\MessageTrait` has been removed. The behavior it provided (using
-  the fully qualified class name as the message name) is now the default.
 - `RetrySpec::retryDelay` method added to allow a message to be delayed when
   retrying, if the driver supports it.
 - `Driver::retry` now accepts an `int $delay` to support delayed retries. Not all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - `MessageLifecycle::failed` no longer has an `$isRetrying` argument, instead
   `MessageLifecycyle::retrying` will be called instead.
+- The `Message` interface no longer has a `getName` method.
+  Instead the *name* of a message is its fully qualified class name. Should the
+  old behavior still be desired, implement `PMG\Queue\NamedMessage` instead.
 
 ### Fixed
 
@@ -20,6 +23,13 @@ n/a
   a message fails and is retrying.
 - `PMG\Queue\Lifecycle\DelegatingLifecycle` has a new named constructor:
   `fromIterable`. This uses PHP 7.1's `iterable` pseudo type.
+- A `PMG\Queue\NamedMessage` interface to enable the old behavior of
+  `Message::getName`.
+
+### Removed
+
+- The `PMG\Queue\MessageTrait` has been removed. The behavior it provided (using
+  the fully qualified class name as the message name) is now the default.
 
 ### Deprecations
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -4,6 +4,77 @@
 
 Stick with version 4.X should PHP 7.0 support be required.
 
+## No More `Message` Names by Default
+
+Previously the `PMG\Queue\Message` interface required a `getName` method. It
+no longer does. Instead the names default to the fully qualified class name
+(FQCN) of the message.
+
+Should the old behavior still be desired, implement the `PMG\Queue\NamedMessage`
+interface which still includes the `getName` method.
+
+The `PMG\Queue\MessageTrait` which provided the FQCN as a name behavior was also
+removed.
+
+#### Version 4.X
+
+```php
+
+namespace Acme\QueueExample;
+
+use PMG\Queue\Message;
+
+final class SomeMessage implements Message
+{
+    public function getName()
+    {
+        return 'SomeMessage';
+    }
+
+    // ...
+}
+```
+
+#### Version 5.X
+
+```php
+
+namespace Acme\QueueExample;
+
+use PMG\Queue\Message;
+
+final class SomeMessage implements Message
+{
+    // message name is now `Acme\QueueExample\SomeMessage`
+    // ...
+}
+```
+
+### Router Updates for Message Names
+
+Additionally, the producers routing configuration may need to be updated.
+
+#### Version 4.X
+
+```php
+use PMG\Queue\Router\MappingRouter;
+
+$router = new MappingRouter([
+  'SomeMessage' => 'queueName',
+]);
+```
+
+#### Version 5.x
+
+```php
+use Acme\QueueExample\SomeMessage;
+use PMG\Queue\Router\MappingRouter;
+
+$router = new MappingRouter([
+   SomeMessage::class => 'queueName',
+]);
+```
+
 ## `MessageLifecycle` Has a New `retrying` Method
 
 Rather than have an `$isRetrying` flag in the `failed` method. If the message is

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -16,7 +16,41 @@ interface which still includes the `getName` method.
 The `PMG\Queue\MessageTrait` which provided the FQCN as a name behavior was also
 removed.
 
-#### Version 4.X
+#### Version 4.X (with FQCN as Message Name)
+
+```php
+
+namespace Acme\QueueExample;
+
+use PMG\Queue\Message;
+
+final class SomeMessage implements Message
+{
+    public function getName()
+    {
+        return __CLASS__;
+    }
+
+    // ...
+}
+```
+
+#### Version 5.X (with FQCN as Message Name)
+
+```php
+
+namespace Acme\QueueExample;
+
+use PMG\Queue\Message;
+
+final class SomeMessage implements Message
+{
+    // message name is now `Acme\QueueExample\SomeMessage`
+    // ...
+}
+```
+
+#### Version 4.X (with Custom Message Name)
 
 ```php
 
@@ -35,17 +69,21 @@ final class SomeMessage implements Message
 }
 ```
 
-#### Version 5.X
+#### Version 5.X (with Custom Message Name)
 
 ```php
 
 namespace Acme\QueueExample;
 
-use PMG\Queue\Message;
+use PMG\Queue\NamedMessage;
 
-final class SomeMessage implements Message
+final class SomeMessage implements NamedMessage
 {
-    // message name is now `Acme\QueueExample\SomeMessage`
+    public function getName()
+    {
+        return 'SomeMessage';
+    }
+
     // ...
 }
 ```

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -24,6 +24,8 @@ use Psr\Log\NullLogger;
  */
 abstract class AbstractConsumer implements Consumer
 {
+    use MessageNames;
+
     /**
      * @var LoggerInterface
      */

--- a/src/DefaultConsumer.php
+++ b/src/DefaultConsumer.php
@@ -116,7 +116,7 @@ class DefaultConsumer extends AbstractConsumer
         $result = false;
         $message = $envelope->unwrap();
 
-        $this->getLogger()->debug('Handling message {msg}', ['msg' => $message->getName()]);
+        $this->getLogger()->debug('Handling message {msg}', ['msg' => self::nameOf($message)]);
         try {
             $result = $this->handleMessage($message);
         } catch (Exception\MustStop $e) {
@@ -125,7 +125,7 @@ class DefaultConsumer extends AbstractConsumer
         } catch (Exception\ShouldReleaseMessage $e) {
             $this->driver->release($queueName, $envelope);
             $this->getLogger()->debug('Releasing message {msg} due to {cls} exception: {err}', [
-                'msg' => $message->getName(),
+                'msg' => self::nameOf($message),
                 'cls' => get_class($e),
                 'err' => $e->getMessage(),
             ]);
@@ -137,20 +137,20 @@ class DefaultConsumer extends AbstractConsumer
             // throws exceptions on failure (see PcntlForkingHandler).
             $this->getLogger()->critical('Unexpected {cls} exception handling {name} message: {msg}', [
                 'cls'   => get_class($e),
-                'name'  => $message->getName(),
+                'name'  => self::nameOf($message),
                 'msg'   => $e->getMessage()
             ]);
             $result = false;
         }
-        $this->getLogger()->debug('Handled message {msg}', ['msg' => $message->getName()]);
+        $this->getLogger()->debug('Handled message {msg}', ['msg' => self::nameOf($message)]);
 
         if ($result) {
             $willRetry = false;
             $this->driver->ack($queueName, $envelope);
-            $this->getLogger()->debug('Acknowledged message {msg}', ['msg' => $message->getName()]);
+            $this->getLogger()->debug('Acknowledged message {msg}', ['msg' => self::nameOf($message)]);
         } else {
             $willRetry = $this->failed($queueName, $envelope);
-            $this->getLogger()->debug('Failed message {msg}', ['msg' => $message->getName()]);
+            $this->getLogger()->debug('Failed message {msg}', ['msg' => self::nameOf($message)]);
         }
 
         return [$result, $willRetry];

--- a/src/DefaultProducer.php
+++ b/src/DefaultProducer.php
@@ -21,6 +21,8 @@ namespace PMG\Queue;
  */
 final class DefaultProducer implements Producer
 {
+    use MessageNames;
+
     /**
      * @var Driver
      */
@@ -44,7 +46,10 @@ final class DefaultProducer implements Producer
     {
         $queueName = $this->router->queueFor($message);
         if (!$queueName) {
-            throw new Exception\QueueNotFound(sprintf('Could not find a queue for "%s"', $message->getName()));
+            throw new Exception\QueueNotFound(sprintf(
+                'Could not find a queue for "%s"',
+                self::nameOf($message)
+            ));
         }
 
         $this->driver->enqueue($queueName, $message);

--- a/src/Lifecycle/MappingLifecycle.php
+++ b/src/Lifecycle/MappingLifecycle.php
@@ -17,6 +17,7 @@ namespace PMG\Queue\Lifecycle;
 use PMG\Queue\Consumer;
 use PMG\Queue\Message;
 use PMG\Queue\MessageLifecycle;
+use PMG\Queue\MessageNames;
 use PMG\Queue\Exception\InvalidArgumentException;
 
 /**
@@ -27,6 +28,8 @@ use PMG\Queue\Exception\InvalidArgumentException;
  */
 final class MappingLifecycle implements MessageLifecycle
 {
+    use MessageNames;
+
     /**
      * A mapping of message names to lifecycles. [$messageName => $lifecycle]
      *
@@ -110,7 +113,7 @@ final class MappingLifecycle implements MessageLifecycle
 
     private function lifecycleFor(Message $message) : MessageLifecycle
     {
-        $name = $message->getName();
+        $name = self::nameOf($message);
         return $this->has($name) ? $this->mapping[$name] : $this->fallback;
     }
 }

--- a/src/Message.php
+++ b/src/Message.php
@@ -20,10 +20,5 @@ namespace PMG\Queue;
  */
 interface Message
 {
-    /**
-     * Get the name of the message. This is used for routing things to queues.
-     *
-     * @return  string
-     */
-    public function getName();
+    // noop
 }

--- a/src/MessageNames.php
+++ b/src/MessageNames.php
@@ -17,6 +17,10 @@ trait MessageNames
 {
     protected static function nameOf(Message $message) : string
     {
-        return $message->getName();
+        if ($message instanceof NamedMessage) {
+            return $message->getName();
+        }
+
+        return get_class($message);
     }
 }

--- a/src/MessageNames.php
+++ b/src/MessageNames.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+trait MessageNames
+{
+    protected static function nameOf(Message $message) : string
+    {
+        return $message->getName();
+    }
+}

--- a/src/MessageTrait.php
+++ b/src/MessageTrait.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+@trigger_error(sprintf('The "%s" trait is deprecated since pmg/queue 5.0, a message\'s FQCN as the message name is the default in 5.0', MessageTrait::class));
+
+/**
+ * ABC for messages, implements `getName` as the class name.
+ *
+ * @since   2015-06-11
+ */
+trait MessageTrait
+{
+    /**
+     * @see NamedMessage::getName
+     */
+    public function getName() : string
+    {
+        return get_class($this);
+    }
+}

--- a/src/NamedMessage.php
+++ b/src/NamedMessage.php
@@ -14,17 +14,16 @@
 namespace PMG\Queue;
 
 /**
- * ABC for messages, implements `getName` as the class name.
+ * Defines a message that has a name other than its fully-qualified class name.
  *
- * @since   2015-06-11
+ * @since   5.0
  */
-trait MessageTrait
+interface NamedMessage extends Message
 {
     /**
-     * @see Message::getName
+     * Get the name of the message. This is used for routing things to queues.
+     *
+     * @return  string
      */
-    public function getName()
-    {
-        return get_class($this);
-    }
+    public function getName() : string;
 }

--- a/src/Router/MappingRouter.php
+++ b/src/Router/MappingRouter.php
@@ -14,6 +14,7 @@
 namespace PMG\Queue\Router;
 
 use PMG\Queue\Message;
+use PMG\Queue\MessageNames;
 use PMG\Queue\Exception\InvalidArgumentException;
 
 /**
@@ -24,6 +25,8 @@ use PMG\Queue\Exception\InvalidArgumentException;
  */
 final class MappingRouter implements \PMG\Queue\Router
 {
+    use MessageNames;
+
     /**
      * The map of class name => queue name values.
      *
@@ -49,7 +52,7 @@ final class MappingRouter implements \PMG\Queue\Router
      */
     public function queueFor(Message $message)
     {
-        $name = $message->getName();
+        $name = self::nameOf($message);
         return isset($this->map[$name]) ? $this->map[$name] : null;
     }
 }

--- a/src/SimpleMessage.php
+++ b/src/SimpleMessage.php
@@ -18,12 +18,12 @@ namespace PMG\Queue;
  *
  * @since   2.0
  */
-final class SimpleMessage implements Message
+final class SimpleMessage implements NamedMessage
 {
     private $name;
     private $payload;
 
-    public function __construct($name, $payload=null)
+    public function __construct(string $name, $payload=null)
     {
         $this->name = $name;
         $this->payload = $payload;
@@ -32,7 +32,7 @@ final class SimpleMessage implements Message
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName() : string
     {
         return $this->name;
     }

--- a/test/unit/DefaultProducerTest.php
+++ b/test/unit/DefaultProducerTest.php
@@ -19,7 +19,7 @@ class DefaultProducerTest extends UnitTestCase
 
     public function testProducerRoutesMessageAndPutsItIntoAQueue()
     {
-        $msg = $this->createMock(Message::class);
+        $msg = new SimpleMessage('test');
         $this->router->expects($this->once())
             ->method('queueFor')
             ->with($this->identicalTo($msg))
@@ -36,7 +36,7 @@ class DefaultProducerTest extends UnitTestCase
      */
     public function testProducerErrorsWhenNoQueueIsFound()
     {
-        $msg = $this->createMock(Message::class);
+        $msg = new SimpleMessage('test');
         $this->router->expects($this->once())
             ->method('queueFor')
             ->with($this->identicalTo($msg))

--- a/test/unit/Lifecycle/MappingLifecycleTest.php
+++ b/test/unit/Lifecycle/MappingLifecycleTest.php
@@ -13,6 +13,7 @@
 
 namespace PMG\Queue\Lifecycle;
 
+use PMG\Queue\MessageNames;
 use PMG\Queue\SimpleMessage;
 use PMG\Queue\Exception\InvalidArgumentException;
 
@@ -21,6 +22,8 @@ use PMG\Queue\Exception\InvalidArgumentException;
  */
 class MappingLifecycleTest extends LifecycleTestCase
 {
+    use MessageNames;
+
     private $child, $fallback, $lifecycle;
 
     public static function badMappings() : array
@@ -97,7 +100,7 @@ class MappingLifecycleTest extends LifecycleTestCase
         $this->child->expects($this->never())
             ->method($method);
         $lc = new MappingLifecycle([
-            $this->message->getName() => $this->child,
+            self::nameOf($this->message) => $this->child,
         ]);
     
         call_user_func([$lc, $method], $message, $this->consumer);
@@ -121,7 +124,7 @@ class MappingLifecycleTest extends LifecycleTestCase
         $this->child = $this->mockLifecycle();
         $this->fallback = $this->mockLifecycle();
         $this->lifecycle = new MappingLifecycle([
-            $this->message->getName() => $this->child,
+            self::nameOf($this->message) => $this->child,
         ], $this->fallback);
     }
 }

--- a/test/unit/MessageNamesTest.php
+++ b/test/unit/MessageNamesTest.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+class MessageNamesTest extends UnitTestCase
+{
+    use MessageNames;
+
+    public function testNameOfReturnsTheValueOfMessageGetName()
+    {
+        $msg = $this->createMock(Message::class);
+        $msg->expects($this->once())
+            ->method('getName')
+            ->willReturn('test');
+
+        $this->assertSame('test', self::nameOf($msg));
+    }
+}

--- a/test/unit/MessageNamesTest.php
+++ b/test/unit/MessageNamesTest.php
@@ -13,17 +13,29 @@
 
 namespace PMG\Queue;
 
+class _NamesTestMsg implements Message
+{
+
+}
+
 class MessageNamesTest extends UnitTestCase
 {
     use MessageNames;
 
     public function testNameOfReturnsTheValueOfMessageGetName()
     {
-        $msg = $this->createMock(Message::class);
+        $msg = $this->createMock(NamedMessage::class);
         $msg->expects($this->once())
             ->method('getName')
             ->willReturn('test');
 
         $this->assertSame('test', self::nameOf($msg));
+    }
+
+    public function testNameOfReturnsTheFullyQualifiedClassNameOfAMessageWhenNotNamed()
+    {
+        $name = self::nameOf(new _NamesTestMsg());
+
+        $this->assertSame(_NamesTestMsg::class, $name);
     }
 }


### PR DESCRIPTION
This changes things so message *names* are their fully qualified class names instead of the value of a `getName` method.

The old behavior is still provided via the `NamedMessage` interface.

Closes #68 