### PR TITLE
Move the Retry Delay into the `Envelope`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `Message` interface no longer has a `getName` method.
   Instead the *name* of a message is its fully qualified class name. Should the
   old behavior still be desired, implement `PMG\Queue\NamedMessage` instead.
-- The `PMG\Queue\MessageTrait` has been deprecated. The behavior it provided (using
-  the fully qualified class name as the message name) is now the default.
 - `PMG\Queue\Router::queueFor` now has a `?string` return type.
+- Drivers should no longer call `Envelope::retry` instead, instead consumers
+  should call this method along with any delay required from the `RetrySpec`.
+  See `UPGRADE-5.0.md` for more details.
 
 ### Fixed
 
@@ -30,7 +31,7 @@ n/a
   `Message::getName`.
 - `RetrySpec::retryDelay` method added to allow a message to be delayed when
   retrying, if the driver supports it.
-- `Driver::retry` now accepts an `int $delay` to support delayed retries. Not all
+- `Envelope::retry` now accepts an `int $delay` to support delayed retries. Not all
   drivers will be able to support delaying.
 
 ### Removed
@@ -42,6 +43,8 @@ n/a
 
 - `PMG\Queue\Lifecycle\DelegatingLifecycle::fromArray`. Use `fromIterable`
   instead.
+- The `PMG\Queue\MessageTrait` has been deprecated. The behavior it provided (using
+  the fully qualified class name as the message name) is now the default.
 
 ## 4.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ n/a
   retrying, if the driver supports it.
 - `Envelope::retry` now accepts an `int $delay` to support delayed retries. Not all
   drivers will be able to support delaying.
+- Similarly, `PMG\Queue\Driver` implementations must no longer call
+  `Envelope::retry` as they were required to do previously. See `UPGRADE-5.0.md`
+  for more details. Instead `PMG\Queue\Consumer` implementations should call
+  `Envelope::retry`.
 
 ### Removed
 

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -199,7 +199,12 @@ final class CustomRouter implements Router
 }
 ```
 
-## Drivers Should No Longer Call `Envelope::retry`
+## Internals
+
+All changes here are only relevant to authors of `PMG\Queue\Driver`,
+`PMG\Queue\Consumer`, or `PMG\Queue\Producer` implementations.
+
+### Drivers Should No Longer Call `Envelope::retry`
 
 In 4.X (and lower) drivers were required to call `$envelope->retry()` on any
 envelope passed in `Driver::retry`.
@@ -239,6 +244,89 @@ final class SomeDriver implements Driver
     public function retry(string $queueName, Envelope $envelope) : void
     {
         $this->queueUpTheMessageSomehow($queueName, $envelope);
+    }
+}
+```
+
+#### Version 4.X Consumer
+
+```php
+use PMG\Queue\Consumer;
+use PMG\Queue\MessageLifecycle;
+use PMG\Queue\RetrySpec;
+
+final class SomeConsumer implements Consumer
+{
+    /**
+     * @var Driver
+     */
+    private $driver;
+
+    /**
+     * @var RetrySpec
+     */
+    private $retries;
+
+    // ...
+
+    public function once(string $queueName, MessageLifecycle $lifecycle=null)
+    {
+        $envelope = $this->driver->dequeue($queueName);
+        if (!$envelope) {
+            return null;
+        }
+
+        try {
+            $this->processTheMessageSomehow($
+        } catch (\Exception $e) {
+            if ($this->retries->canRetry($envelope)) {
+                $this->driver->retry($envelope); // <-- No `$envelope->retry(...)`
+            } else {
+                $this->driver->fail($envelope);
+            }
+        }
+    }
+}
+```
+
+#### Version 5.X Consumer
+
+```php
+use PMG\Queue\Consumer;
+use PMG\Queue\MessageLifecycle;
+use PMG\Queue\RetrySpec;
+
+final class SomeConsumer implements Consumer
+{
+    /**
+     * @var Driver
+     */
+    private $driver;
+
+    /**
+     * @var RetrySpec
+     */
+    private $retries;
+
+    // ...
+
+    public function once(string $queueName, MessageLifecycle $lifecycle=null)
+    {
+        $envelope = $this->driver->dequeue($queueName);
+        if (!$envelope) {
+            return null;
+        }
+
+        try {
+            $this->processTheMessageSomehow($
+        } catch (\Exception $e) {
+            if ($this->retries->canRetry($envelope)) {
+                $delay = $this->retries->retryDelay($envelope);
+                $this->driver->retry($envelope->retry($delay)); // <-- Call `$envelope->retry(...)`
+            } else {
+                $this->driver->fail($envelope);
+            }
+        }
     }
 }
 ```

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -198,3 +198,47 @@ final class CustomRouter implements Router
     }
 }
 ```
+
+## Drivers Should No Longer Call `Envelope::retry`
+
+In 4.X (and lower) drivers were required to call `$envelope->retry()` on any
+envelope passed in `Driver::retry`.
+
+That should now happen in implements of `PMG\Queue\Consumer` instead.
+
+#### Version 4.X Driver
+
+```php
+use PMG\Queue\Driver;
+use PMG\Queue\Envelope;
+
+final class SomeDriver implements Driver
+{
+    // ...
+
+    public function retry(string $queueName, Envelope $envelope) : Envelope
+    {
+        $e = $envelope->retry();
+        $this->queueUpTheMessageSomehow($queueName, $e);
+
+        return $e;
+    }
+}
+```
+
+#### Version 5.X Driver
+
+```php
+use PMG\Queue\Driver;
+use PMG\Queue\Envelope;
+
+final class SomeDriver implements Driver
+{
+    // ...
+
+    public function retry(string $queueName, Envelope $envelope) : void
+    {
+        $this->queueUpTheMessageSomehow($queueName, $envelope);
+    }
+}
+```

--- a/src/DefaultConsumer.php
+++ b/src/DefaultConsumer.php
@@ -168,7 +168,7 @@ class DefaultConsumer extends AbstractConsumer
         $retry = $this->retries->canRetry($env);
         if ($retry) {
             $delay = $this->retries->retryDelay($env);
-            $this->getDriver()->retry($queueName, $env, $delay);
+            $this->getDriver()->retry($queueName, $env->retry($delay));
         } else {
             $this->getDriver()->fail($queueName, $env);
         }

--- a/src/DefaultEnvelope.php
+++ b/src/DefaultEnvelope.php
@@ -23,7 +23,7 @@ class DefaultEnvelope implements Envelope
     protected $message;
     protected $attempts;
 
-    public function __construct(Message $message, $attempts=0)
+    public function __construct(Message $message, int $attempts=0)
     {
         $this->message = $message;
         $this->attempts = $attempts;
@@ -32,7 +32,7 @@ class DefaultEnvelope implements Envelope
     /**
      * {@inheritdoc}
      */
-    public function attempts()
+    public function attempts() : int
     {
         return $this->attempts;
     }
@@ -40,7 +40,7 @@ class DefaultEnvelope implements Envelope
     /**
      * {@inheritdoc}
      */
-    public function unwrap()
+    public function unwrap() : Message
     {
         return $this->message;
     }
@@ -48,7 +48,7 @@ class DefaultEnvelope implements Envelope
     /**
      * {@inheritdoc}
      */
-    public function retry()
+    public function retry() : Envelope
     {
         $new = clone $this;
         $new->attempts++;

--- a/src/DefaultEnvelope.php
+++ b/src/DefaultEnvelope.php
@@ -13,6 +13,8 @@
 
 namespace PMG\Queue;
 
+use PMG\Queue\Exception\InvalidArgumentException as InvalidArg;
+
 /**
  * Default implementation of the `Envelop` with no extras.
  *
@@ -20,13 +22,27 @@ namespace PMG\Queue;
  */
 class DefaultEnvelope implements Envelope
 {
+    /**
+     * @var Message
+     */
     protected $message;
+
+    /**
+     * @var int
+     */
     protected $attempts;
 
-    public function __construct(Message $message, int $attempts=0)
+    /**
+     * @var int
+     */
+    private $delay;
+
+    public function __construct(Message $message, int $attempts=0, int $delay=Envelope::NO_DELAY)
     {
+        InvalidArg::assert($attempts >= 0, '$attempts must be >= 0');
         $this->message = $message;
         $this->attempts = $attempts;
+        $this->setDelay($delay);
     }
 
     /**
@@ -40,6 +56,14 @@ class DefaultEnvelope implements Envelope
     /**
      * {@inheritdoc}
      */
+    public function delay() : int
+    {
+        return $this->delay;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function unwrap() : Message
     {
         return $this->message;
@@ -48,10 +72,11 @@ class DefaultEnvelope implements Envelope
     /**
      * {@inheritdoc}
      */
-    public function retry() : Envelope
+    public function retry(int $delay=0) : Envelope
     {
         $new = clone $this;
         $new->attempts++;
+        $new->setDelay($delay);
 
         return $new;
     }
@@ -73,5 +98,11 @@ class DefaultEnvelope implements Envelope
                 get_class($this->message)
             ));
         }
+    }
+
+    protected function setDelay(int $delay) : void
+    {
+        InvalidArg::assert($delay >= 0, '$delay must be >= 0');
+        $this->delay = $delay;
     }
 }

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -64,11 +64,10 @@ interface Driver
      * @param   string $queueName The queue from whcih the message came
      * @param   $envelope The message envelope -- should be the same instance
      *          returned from `dequeue`
-     * @param   int $delay The number of seconds to wait before retrying
      * @throws  Exception\DriverError when something goes wrong
      * @return  Envelope The new envelope for the retried job.
      */
-    public function retry(string $queueName, Envelope $envelope, int $delay=0) : Envelope;
+    public function retry(string $queueName, Envelope $envelope) : Envelope;
 
     /**
      * Fail a job -- this called when no more retries can be attempted.

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -65,9 +65,9 @@ interface Driver
      * @param   $envelope The message envelope -- should be the same instance
      *          returned from `dequeue`
      * @throws  Exception\DriverError when something goes wrong
-     * @return  Envelope The new envelope for the retried job.
+     * @return  void
      */
-    public function retry(string $queueName, Envelope $envelope) : Envelope;
+    public function retry(string $queueName, Envelope $envelope) : void;
 
     /**
      * Fail a job -- this called when no more retries can be attempted.

--- a/src/Driver/MemoryDriver.php
+++ b/src/Driver/MemoryDriver.php
@@ -62,7 +62,7 @@ final class MemoryDriver implements \PMG\Queue\Driver
     /**
      * {@inheritdoc}
      */
-    public function retry(string $queueName, Envelope $envelope, int $delay=0) : Envelope
+    public function retry(string $queueName, Envelope $envelope) : Envelope
     {
         $this->enqueueEnvelope($queueName, $envelope);
         return $envelope;

--- a/src/Driver/MemoryDriver.php
+++ b/src/Driver/MemoryDriver.php
@@ -62,10 +62,9 @@ final class MemoryDriver implements \PMG\Queue\Driver
     /**
      * {@inheritdoc}
      */
-    public function retry(string $queueName, Envelope $envelope) : Envelope
+    public function retry(string $queueName, Envelope $envelope) : void
     {
         $this->enqueueEnvelope($queueName, $envelope);
-        return $envelope;
     }
 
     /**

--- a/src/Driver/MemoryDriver.php
+++ b/src/Driver/MemoryDriver.php
@@ -64,9 +64,8 @@ final class MemoryDriver implements \PMG\Queue\Driver
      */
     public function retry(string $queueName, Envelope $envelope, int $delay=0) : Envelope
     {
-        $e = $envelope->retry();
-        $this->enqueueEnvelope($queueName, $e);
-        return $e;
+        $this->enqueueEnvelope($queueName, $envelope);
+        return $envelope;
     }
 
     /**

--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -23,12 +23,21 @@ namespace PMG\Queue;
  */
 interface Envelope
 {
+    const NO_DELAY = 0;
+
     /**
      * Get the number of times the message has been attempted.
      *
      * @return  int
      */
     public function attempts() : int;
+
+    /**
+     * Get the number of seconds which the message should be delayed.
+     *
+     * @return int
+     */
+    public function delay() : int;
 
     /**
      * Get the wrapped message.
@@ -41,7 +50,8 @@ interface Envelope
      * Returns a new envelop with all the same attributes but an incremented
      * attempt count.
      *
+     * @param $delay The amount number of seconds the message should be delayed before retrying
      * @return  Envelop
      */
-    public function retry() : Envelope;
+    public function retry(int $delay=0) : Envelope;
 }

--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -28,14 +28,14 @@ interface Envelope
      *
      * @return  int
      */
-    public function attempts();
+    public function attempts() : int;
 
     /**
      * Get the wrapped message.
      *
      * @return  Message
      */
-    public function unwrap();
+    public function unwrap() : Message;
 
     /**
      * Returns a new envelop with all the same attributes but an incremented
@@ -43,5 +43,5 @@ interface Envelope
      *
      * @return  Envelop
      */
-    public function retry();
+    public function retry() : Envelope;
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -28,4 +28,11 @@ final class InvalidArgumentException extends \InvalidArgumentException implement
             throw new self($message);
         }
     }
+
+    public static function assert(bool $ok, string $message, int $code=0) : void
+    {
+        if (!$ok) {
+            throw new self($message, $code);
+        }
+    }
 }

--- a/test/unit/DefaultEnvelopeTest.php
+++ b/test/unit/DefaultEnvelopeTest.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+/**
+ * This file is part of PMG\Queue
+ *
+ * Copyright (c) PMG <https://www.pmg.com>
+ *
+ * For full copyright information see the LICENSE file distributed
+ * with this source code.
+ *
+ * @license     http://opensource.org/licenses/Apache-2.0 Apache-2.0
+ */
+
+namespace PMG\Queue;
+
+use PMG\Queue\Exception\InvalidArgumentException as InvalidArg;
+
+class DefaultEnvelopeTest extends UnitTestCase
+{
+    private $message;
+
+    public function testEnvelopeCannotBeCreatedWithAttempsLessThanZero()
+    {
+        $this->expectException(InvalidArg::class);
+        new DefaultEnvelope($this->message, -1);
+    }
+
+    public function testEnvelopeCannotBeCreatedWithDelayLessThanZero()
+    {
+        $this->expectException(InvalidArg::class);
+        new DefaultEnvelope($this->message, 0, -1);
+    }
+
+    public function testRetrySetsTheDelayProvidedOnTheNewEnvelope()
+    {
+        $e = new DefaultEnvelope($this->message);
+
+        $retry = $e->retry(10);
+
+        $this->assertEquals(10, $retry->delay());
+    }
+
+    public function testMessageCannotBeRetriedWithADelayLessThanZero()
+    {
+        $this->expectException(InvalidArg::class);
+        $e = new DefaultEnvelope($this->message);
+
+        $e->retry(-1);
+    }
+
+    protected function setUp()
+    {
+        $this->message = new SimpleMessage('test');
+    }
+}


### PR DESCRIPTION
There's a kinda hard BC break here with driver not needing to call `Envelope::retry` any longer.

Closes #58 