### PR TITLE
Drop PHP 7.1 Support for 5.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
-php:
-    - 7.1
-    - 7.2
+php: '7.2'
 
 notifications:
     email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- PHP 7.2+ is required.
 - `MessageLifecycle::failed` no longer has an `$isRetrying` argument, instead
   `MessageLifecycyle::retrying` will be called instead.
 - The `Message` interface no longer has a `getName` method.

--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -1,8 +1,8 @@
 # Upgrade from 4.X to 5.X
 
-## PHP Version Requirement Bumped to ~7.1
+## PHP Version Requirement Bumped to ~7.2
 
-Stick with version 4.X should PHP 7.0 support be required.
+Stick with version 4.X should PHP 7.0 or 7.1 support be required.
 
 ## No More `Message` Names by Default
 

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
         { "name": "Christopher Davis", "email": "chris@pmg.com" }
     ],
     "require": {
-        "php": "~7.1",
+        "php": "~7.2",
         "psr/log": "~1.0",
         "guzzlehttp/promises": "~1.3"
 
     },
     "require-dev": {
-        "phpunit/phpunit": "~6.0",
+        "phpunit/phpunit": "~7.0",
         "paragonie/sodium_compat": "~1.4"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="test/bootstrap.php">
 
     <testsuites>


### PR DESCRIPTION
Main reason we kept 7.1 support around was for some applications at PMG, need to follow the communities lead here and be a bit more aggressive about PHP versions.