### PR TITLE
Include the Full Exception in Log Message Contexts

### DIFF
--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -66,6 +66,7 @@ abstract class AbstractConsumer implements Consumer
             } catch (Exception\MustStop $e) {
                 $this->getLogger()->warning('Caught a must stop exception, exiting: {msg}', [
                     'msg'   => $e->getMessage(),
+                    'exception' => $e,
                 ]);
                 $this->stop($e->getCode());
             } catch (\Throwable $e) {
@@ -95,11 +96,12 @@ abstract class AbstractConsumer implements Consumer
         return $this->logger;
     }
 
-    protected function logFatalAndStop($exception)
+    protected function logFatalAndStop(\Throwable $exception)
     {
         $this->getLogger()->emergency('Caught an unexpected {cls} exception, exiting: {msg}', [
             'cls' => get_class($exception),
             'msg' => $exception->getMessage(),
+            'exception' => $exception,
         ]);
         $this->stop(self::EXIT_ERROR);
     }

--- a/src/DefaultConsumer.php
+++ b/src/DefaultConsumer.php
@@ -128,6 +128,7 @@ class DefaultConsumer extends AbstractConsumer
                 'msg' => self::nameOf($message),
                 'cls' => get_class($e),
                 'err' => $e->getMessage(),
+                'exception' => $e,
             ]);
             return [$result, true];
         } catch (\Exception $e) {
@@ -138,7 +139,8 @@ class DefaultConsumer extends AbstractConsumer
             $this->getLogger()->critical('Unexpected {cls} exception handling {name} message: {msg}', [
                 'cls'   => get_class($e),
                 'name'  => self::nameOf($message),
-                'msg'   => $e->getMessage()
+                'msg'   => $e->getMessage(),
+                'exception' => $e,
             ]);
             $result = false;
         }


### PR DESCRIPTION
So users can get thigns like stack traces and such out of it depending
on their logger implementation.