### PR TITLE
Change Span Names When No Message is Handled

### DIFF
--- a/src/Otel/PmgQueueInstrumentation.php
+++ b/src/Otel/PmgQueueInstrumentation.php
@@ -112,6 +112,8 @@ final class PmgQueueInstrumentation
                     $span->setStatus(StatusCode::STATUS_ERROR, $exception->getMessage());
                 } elseif ($result === false) {
                     $span->setStatus(StatusCode::STATUS_ERROR, 'Message was not handled successfully');
+                } elseif ($result === null) {
+                    $span->updateName($queueName.' empty-receive');
                 }
 
                 $span->end();

--- a/test/integration/ConsumerOtelIntTest.php
+++ b/test/integration/ConsumerOtelIntTest.php
@@ -43,7 +43,7 @@ class ConsumerOtelIntTest extends OtelIntegrationTestCase
         $this->assertFalse($called);
         $this->assertCount(1, $this->spans);
         $span = $this->spans[0];
-        $this->assertSame(self::Q.' receive', $span->getName());
+        $this->assertSame(self::Q.' empty-receive', $span->getName());
         $attr = $span->getAttributes();
         $this->assertSame(self::Q, $attr->get(TraceAttributes::MESSAGING_DESTINATION_NAME));
         $this->assertSame('receive', $attr->get(PmgQueueInstrumentation::OPERATION_TYPE));


### PR DESCRIPTION
With the idea being to make these spans easier to drop.